### PR TITLE
Feature/frontend provider context setup

### DIFF
--- a/wee/frontend/specs/component/Home.spec.tsx
+++ b/wee/frontend/specs/component/Home.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import Home from '../../src/app/(pages)/page';
 import { useRouter } from 'next/navigation';
-import { useScrapingContext } from 'frontend/src/app/context/ScrapingContext';
+import {useScrapingContext} from '../../src/app/context/ScrapingContext'
 
 // Mock the useRouter hook
 jest.mock('next/navigation', () => ({

--- a/wee/frontend/specs/component/Home.spec.tsx
+++ b/wee/frontend/specs/component/Home.spec.tsx
@@ -2,15 +2,28 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import Home from '../../src/app/(pages)/page';
 import { useRouter } from 'next/navigation';
+import { useScrapingContext } from 'frontend/src/app/context/ScrapingContext';
 
 // Mock the useRouter hook
 jest.mock('next/navigation', () => ({
     useRouter: jest.fn(),
 }));
 
+jest.mock('frontend/src/app/context/ScrapingContext', () => ({
+    useScrapingContext: jest.fn(),
+}));
+
 jest.useFakeTimers();
 
 describe('Home Component', () => {
+    const mockUrls = ['https://www.example.com', 'https://www.example2.com'];
+    const mockPush = jest.fn();
+
+    beforeEach(() => {
+        (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+        (useScrapingContext as jest.Mock).mockReturnValue({ urls: mockUrls }); 
+    });
+
     it('should display error message when URL is empty', () => {
         render(<Home />);
 
@@ -33,18 +46,29 @@ describe('Home Component', () => {
     });
 
     it('should navigate to results page with valid URL', () => {
-        const push = jest.fn();
-        (useRouter as jest.Mock).mockReturnValue({ push });
+        const mockSetUrls = jest.fn();
+        const mockRouterPush = jest.fn();
+        const mockSetError = jest.fn();
+
+        (useScrapingContext as jest.Mock).mockReturnValue({
+            setUrls: mockSetUrls,
+        });
+
+        (useRouter as jest.Mock).mockReturnValue({ push: mockRouterPush });
 
         render(<Home />);
 
-        const input = screen.getByPlaceholderText('Enter the URLs you want to scrape comma seperated');
-        const button = screen.getByRole('button', { name: /Start scraping/i });
+        const textarea = screen.getByTestId('scraping-textarea-home');
+        fireEvent.change(textarea, { target: { value: 'https://www.example.com' } });
 
-        fireEvent.change(input, { target: { value: 'https://www.example.com' } });
+        const button = screen.getByRole('button', { name: /Start scraping/i });
         fireEvent.click(button);
 
-        expect(push).toHaveBeenCalledWith('/scraperesults?urls=https%3A%2F%2Fwww.example.com');
+        expect(mockSetUrls).toHaveBeenCalledWith(['https://www.example.com']);
+
+        expect(mockRouterPush).toHaveBeenCalledWith('/scraperesults');
+
+        expect(mockSetError).not.toHaveBeenCalled();
     });
 
     it('should clear error message after 3 seconds', () => {

--- a/wee/frontend/specs/component/Results.spec.tsx
+++ b/wee/frontend/specs/component/Results.spec.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { render, screen, act, waitFor } from '@testing-library/react';
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
 import Results from '../../src/app/(pages)/results/page'; // Adjust the import according to your file structure
 import { useSearchParams } from 'next/navigation';
 import { ScrapingProvider } from 'frontend/src/app/provider/ScrapingProvider';
 import { useRouter } from 'next/navigation';
+import { useScrapingContext } from 'frontend/src/app/context/ScrapingContext';
 
 // Mock the useSearchParams hook
 jest.mock('next/navigation', () => ({
@@ -11,29 +12,97 @@ jest.mock('next/navigation', () => ({
     useRouter: jest.fn(),
 }));
 
+jest.mock('frontend/src/app/context/ScrapingContext', () => ({
+    useScrapingContext: jest.fn(),
+}));
+
 describe('Results Component', () => {
     const mockUrl = 'https://www.example.com';
+    const mockPush = jest.fn();
+
+    const mockResults = [
+        {
+            url: mockUrl,
+            robots: { isUrlScrapable: true },
+            domainStatus: 'live',
+            logo: 'https://www.example.com/logo.png',
+            images: ['https://www.example.com/image1.png', 'https://www.example.com/image2.png'],
+            industryClassification: {
+                metadataClass: { label: 'E-commerce', score: 95 },
+                domainClass: { label: 'Retail', score: 90 },
+            },
+        },
+    ];
 
     beforeEach(() => {
         (useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams(`url=${mockUrl}`));   
-        (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });    
+        (useRouter as jest.Mock).mockReturnValue({ push: mockPush });   
+        (useScrapingContext as jest.Mock).mockReturnValue({ results: mockResults }); 
     });
 
-    it('should display website status, crawlable status, and industry classification', async () => {
+    it('should display website status, crawlable status, industry classification, and domain classification', async () => {
         await act(async () => {
-            render(
-                <ScrapingProvider>
-                    <Results />
-                </ScrapingProvider>
-            );
+            render(<Results />);
         });
-
-        screen.debug();
 
         await waitFor(() => {
             expect(screen.queryByText('Yes')).toBeDefined();
             expect(screen.queryByText('Live')).toBeDefined();
-            expect(screen.queryByText('E-commerce')).toBeDefined();
+            expect(screen.queryByText('E-commerce - 95')).toBeDefined();
+            expect(screen.queryByText('Retail - 90')).toBeDefined();
         });
+    });
+
+    it('should display no logo available when logo is not present', async () => {
+        (useScrapingContext as jest.Mock).mockReturnValueOnce({
+            results: [
+                {
+                    ...mockResults[0],
+                    logo: '',
+                },
+            ],
+        });
+
+        await act(async () => {
+            render(<Results />);
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('No logo available.')).toBeDefined();
+        });
+    });
+
+    it('should display no images available when images are not present', async () => {
+        (useScrapingContext as jest.Mock).mockReturnValueOnce({
+            results: [
+                {
+                    ...mockResults[0],
+                    images: [],
+                },
+            ],
+        });
+
+        await act(async () => {
+            render(<Results />);
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('No images available.')).toBeDefined();
+        });
+    });
+
+    it('should navigate back to scrape results when Back button is clicked', async () => {
+        await act(async () => {
+            render(<Results />);
+        });
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: /Back/i })).toBeDefined();
+        });
+
+        const backButton = screen.getByRole('button', { name: /Back/i });
+        fireEvent.click(backButton);
+
+        expect(mockPush).toHaveBeenCalledWith('/scraperesults');
     });
 });

--- a/wee/frontend/specs/component/Results.spec.tsx
+++ b/wee/frontend/specs/component/Results.spec.tsx
@@ -1,30 +1,39 @@
 import React from 'react';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, waitFor } from '@testing-library/react';
 import Results from '../../src/app/(pages)/results/page'; // Adjust the import according to your file structure
 import { useSearchParams } from 'next/navigation';
+import { ScrapingProvider } from 'frontend/src/app/provider/ScrapingProvider';
+import { useRouter } from 'next/navigation';
 
 // Mock the useSearchParams hook
 jest.mock('next/navigation', () => ({
     useSearchParams: jest.fn(),
+    useRouter: jest.fn(),
 }));
 
 describe('Results Component', () => {
     const mockUrl = 'https://www.example.com';
-    const mockWebsiteStatus = 'true';
-    const mockIsCrawlable = 'true';
-    const mockIndustry = 'E-commerce';
 
     beforeEach(() => {
-        (useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams(`url=${mockUrl}&websiteStatus=${mockWebsiteStatus}&isCrawlable=${mockIsCrawlable}&industry=${mockIndustry}`));       
+        (useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams(`url=${mockUrl}`));   
+        (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });    
     });
 
     it('should display website status, crawlable status, and industry classification', async () => {
         await act(async () => {
-            render(<Results />);
+            render(
+                <ScrapingProvider>
+                    <Results />
+                </ScrapingProvider>
+            );
         });
 
-        expect(screen.getByText('Yes')).toBeDefined();
-        expect(screen.getByText('Live')).toBeDefined();
-        expect(screen.getByText('E-commerce')).toBeDefined();
+        screen.debug();
+
+        await waitFor(() => {
+            expect(screen.queryByText('Yes')).toBeDefined();
+            expect(screen.queryByText('Live')).toBeDefined();
+            expect(screen.queryByText('E-commerce')).toBeDefined();
+        });
     });
 });

--- a/wee/frontend/specs/component/Results.spec.tsx
+++ b/wee/frontend/specs/component/Results.spec.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
 import Results from '../../src/app/(pages)/results/page'; // Adjust the import according to your file structure
 import { useSearchParams } from 'next/navigation';
-import { ScrapingProvider } from 'frontend/src/app/provider/ScrapingProvider';
 import { useRouter } from 'next/navigation';
-import { useScrapingContext } from 'frontend/src/app/context/ScrapingContext';
+import {useScrapingContext} from '../../src/app/context/ScrapingContext'
 
 // Mock the useSearchParams hook
 jest.mock('next/navigation', () => ({

--- a/wee/frontend/specs/component/ScrapeResult.spec.tsx
+++ b/wee/frontend/specs/component/ScrapeResult.spec.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
-import ScrapeResults from 'frontend/src/app/(pages)/scraperesults/page';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import ScrapeResults from '../../src/app/(pages)/scraperesults/page'; // Adjust the import according to your file structure
 
 import { useRouter } from 'next/navigation';
-import { useScrapingContext } from 'frontend/src/app/context/ScrapingContext';
 
 jest.mock('next/navigation', () => ({
     useRouter: jest.fn(),

--- a/wee/frontend/specs/component/ScrapeResult.spec.tsx
+++ b/wee/frontend/specs/component/ScrapeResult.spec.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
+import ScrapeResults from 'frontend/src/app/(pages)/scraperesults/page';
+
+import { useRouter } from 'next/navigation';
+import { useScrapingContext } from 'frontend/src/app/context/ScrapingContext';
+
+jest.mock('next/navigation', () => ({
+    // useSearchParams: jest.fn(),
+    useRouter: jest.fn(),
+}));
+
+jest.mock('frontend/src/app/context/ScrapingContext', () => ({
+    useScrapingContext: () => ({
+        urls: ['https://www.example.com', 'https://www.example2.com'],
+        setUrls: jest.fn(),
+        results: [        
+            {
+                url: 'https://www.example.com',
+                robots: { isUrlScrapable: false },
+            },
+            {
+                url: 'https://www.example2.com',
+                robots: { isUrlScrapable: true },
+            },
+        ], 
+        setResults: jest.fn(),
+    }),
+}));
+
+describe('Scrape Results Component', () => {
+    beforeEach(() => {
+        jest.clearAllMocks(); // Clear all mock function calls before each test
+    });
+
+    it('should display 2 results', async () => {
+        await act(async () => {
+            render(<ScrapeResults />);
+        });
+
+        expect(screen.getByText('Total 2 results')).toBeDefined();
+    });
+
+    it('should filter items based on searchValue', () => {
+        render(<ScrapeResults />);
+
+        // Initially, no search filter should return all items
+        expect(screen.getByText('https://www.example.com')).toBeDefined();
+        expect(screen.getByText('https://www.example2.com')).toBeDefined();
+
+        // Simulate setting a search filter
+        const searchInput = screen.getByPlaceholderText('https://www.takealot.com/');
+        fireEvent.change(searchInput, { target: { value: 'example2' } });
+
+        // After setting the search filter, only the matching item should be visible
+        expect(screen.queryByText('https://www.example.com')).toBeNull();
+        expect(screen.getByText('https://www.example2.com')).toBeDefined();
+    });
+
+    it('should not filter items when searchValue is empty', () => {
+        render(<ScrapeResults />);
+
+        // Initially, no search filter should return all items
+        expect(screen.getByText('https://www.example.com')).toBeDefined();
+        expect(screen.getByText('https://www.example2.com')).toBeDefined();
+
+        // Simulate clearing the search filter (empty searchValue)
+        const searchInput = screen.getByPlaceholderText('https://www.takealot.com/');
+        fireEvent.change(searchInput, { target: { value: '' } });
+
+        // After clearing the search filter, all items should be visible again
+        expect(screen.getByText('https://www.example.com')).toBeDefined();
+        expect(screen.getByText('https://www.example2.com')).toBeDefined();
+    });
+
+});

--- a/wee/frontend/src/app/(pages)/page.tsx
+++ b/wee/frontend/src/app/(pages)/page.tsx
@@ -7,7 +7,7 @@ import WEETextarea from "../components/Util/Textarea";
 import { useScrapingContext } from "../context/ScrapingContext";
 
 export default function Home() {
-    const {setUrls, results, setResults} = useScrapingContext();
+    const {setUrls} = useScrapingContext();
     const router = useRouter();
     const [url, setUrl] = useState('');
     const [error, setError] = useState('');

--- a/wee/frontend/src/app/(pages)/page.tsx
+++ b/wee/frontend/src/app/(pages)/page.tsx
@@ -1,14 +1,24 @@
 'use client'
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Button, Checkbox } from '@nextui-org/react';
 import { useRouter } from 'next/navigation';
 import { MdErrorOutline } from "react-icons/md";
 import WEETextarea from "../components/Util/Textarea";
+import { useScrapingContext } from "../context/ScrapingContext";
 
 export default function Home() {
+    // const {results, setResults, urls, setUrls, test} = useScrapingContext();
     const router = useRouter();
     const [url, setUrl] = useState('');
     const [error, setError] = useState('');
+
+    // useEffect(() => {
+    //   setUrls(['test1', 'test2', 'test3']);
+    // }, [])
+
+    // useEffect(() => {
+    //   console.log('Urls on the home page', urls);
+    // },[urls])
    
     const isValidUrl = (urlString: string) => {
         try {

--- a/wee/frontend/src/app/(pages)/page.tsx
+++ b/wee/frontend/src/app/(pages)/page.tsx
@@ -74,6 +74,7 @@ export default function Home() {
         </div>
         <div className="flex flex-col sm:flex-row w-full justify-center items-center">
           <WEETextarea
+            data-testid="scraping-textarea-home"
             minRows={1}
             label="URLs to scrape"
             placeholder="Enter the URLs you want to scrape comma seperated"

--- a/wee/frontend/src/app/(pages)/page.tsx
+++ b/wee/frontend/src/app/(pages)/page.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Button, Checkbox } from '@nextui-org/react';
 import { useRouter } from 'next/navigation';
 import { MdErrorOutline } from "react-icons/md";
@@ -7,18 +7,10 @@ import WEETextarea from "../components/Util/Textarea";
 import { useScrapingContext } from "../context/ScrapingContext";
 
 export default function Home() {
-    // const {results, setResults, urls, setUrls, test} = useScrapingContext();
+    const {setUrls, results, setResults} = useScrapingContext();
     const router = useRouter();
     const [url, setUrl] = useState('');
     const [error, setError] = useState('');
-
-    // useEffect(() => {
-    //   setUrls(['test1', 'test2', 'test3']);
-    // }, [])
-
-    // useEffect(() => {
-    //   console.log('Urls on the home page', urls);
-    // },[urls])
    
     const isValidUrl = (urlString: string) => {
         try {
@@ -30,32 +22,34 @@ export default function Home() {
     };
 
     const handleScraping = () => {
-        if (!url) {
-            setError('URL cannot be empty');
+      if (!url) {
+          setError('URL cannot be empty');
 
-            const timer = setTimeout(() => {
-                setError('');
-            }, 3000);
+          const timer = setTimeout(() => {
+              setError('');
+          }, 3000);
 
-            return () => clearTimeout(timer);
-        }
+          return () => clearTimeout(timer);
+      }
 
-        const urls = url.split(',').map(u => u.trim());
-        for (const singleUrl of urls) {
+      const urlsToScrape = url.split(',').map(u => u.trim());
+      for (const singleUrl of urlsToScrape) {
 
-            if (!isValidUrl(singleUrl)) {
-                setError('Please enter valid URLs');
-    
-                const timer = setTimeout(() => {
-                    setError('');
-                }, 3000);
-    
-                return () => clearTimeout(timer);
-            }
-        }
-        setError('');
-        // Navigate to Results page with the entered URL as query parameter
-        router.push(`/scraperesults?urls=${encodeURIComponent(url)}`)
+          if (!isValidUrl(singleUrl)) {
+              setError('Please enter valid URLs');
+  
+              const timer = setTimeout(() => {
+                  setError('');
+              }, 3000);
+  
+              return () => clearTimeout(timer);
+          }
+      }
+      setError('');
+
+      // Navigate to Results page with the entered URL as query parameter
+      setUrls(urlsToScrape);
+      router.push(`/scraperesults`);
     };
 
     return (

--- a/wee/frontend/src/app/(pages)/results/page.tsx
+++ b/wee/frontend/src/app/(pages)/results/page.tsx
@@ -24,15 +24,13 @@ export default function Results() {
 function ResultsComponent() {
     const searchParams = useSearchParams();
     const url = searchParams.get('url');
-    const {urls, setUrls, results, setResults} = useScrapingContext();
+
+    const { results } = useScrapingContext();
 
     const router = useRouter();
-    // const websiteStatusUrl = searchParams.get('websiteStatus');
-    // const isCrawlableUrl = searchParams.get('isCrawlable');
-    // const industryUrl = searchParams.get('industry');
+
     const [websiteStatus, setWebsiteStatus] = useState('');
     const [isCrawlable, setIsCrawlable] = useState(false);
-    const [isLoading, setIsLoading] = useState(false);
     const [industryClassification, setIndustryClassification] = useState<Classifications>();
     const [domainClassification, setDomainClassification] = useState<Classifications>();
     const [logo, setLogo] = useState('');
@@ -40,9 +38,8 @@ function ResultsComponent() {
 
     useEffect(() => {
         if (url) {
-            console.log('URL on the individual report page', url);
             const urlResults = results.filter((res) => res.url === url);
-            console.log('URL RESULTS TO DISPLAY', urlResults);
+            
             if (urlResults && urlResults[0]) {
                 setIsCrawlable(urlResults[0].robots.isUrlScrapable)
                 setWebsiteStatus(urlResults[0].domainStatus);
@@ -54,42 +51,8 @@ function ResultsComponent() {
         }
     }, [url]);
 
-    // const fetchLogo = async (url: string) => {
-    //     try {
-    //         const response = await fetch(`http://localhost:3000/api/scrapeLogos?url=${encodeURIComponent(url)}`);
-    //         setLogo(await response.text());
-    //     } catch (error) {
-    //         console.error('Error fetching logo:', error);
-    //     } 
-    // }
-
-    // const fetchImages = async (url: string) => {
-    //     try {
-    //         const response = await fetch(`http://localhost:3000/api/scrapeImages?url=${encodeURIComponent(url)}`);
-    //         const data = await response.json();
-    //         console.log(data);
-    //         setImageList(data);
-    //     } catch (error) {
-    //         console.error('Error fetching images:', error);
-    //     } finally { 
-    //         setIsLoading(false);
-    //     }
-    // }
-
     const backToScrapeResults = () => {
         router.push(`/scraperesults`);
-    }
-
-    if (isLoading) {
-        return (
-            <div className='min-h-screen flex justify-center items-center'>
-                <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-current border-e-transparent align-[-0.125em] text-surface motion-reduce:animate-[spin_1.5s_linear_infinite] dark:text-white" role="status">
-                    <span className="!absolute !-m-px !h-px !w-px !overflow-hidden !whitespace-nowrap !border-0 !p-0 ![clip:rect(0,0,0,0)]">
-                        Loading...
-                    </span>
-                </div>
-            </div>
-        );
     }
     
     return (

--- a/wee/frontend/src/app/(pages)/results/page.tsx
+++ b/wee/frontend/src/app/(pages)/results/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 import React, { useEffect, useState, Suspense } from 'react';
 import { Card, CardBody, Image } from "@nextui-org/react";
-import { Table, TableHeader, TableColumn, TableBody, TableRow, TableCell } from "@nextui-org/react";
+import { Button, TableHeader, TableColumn, TableBody, TableRow, TableCell } from "@nextui-org/react";
 import { Chip } from "@nextui-org/react";
 import { useSearchParams } from 'next/navigation';
 import { IndustryClassification } from '../../models/IndustryModel';
 import WEETable from '../../components/Util/Table';
+import { useRouter } from 'next/navigation';
+import { useScrapingContext } from '../../context/ScrapingContext';
 
 export default function Results() {
     return (
@@ -18,9 +20,11 @@ export default function Results() {
 function ResultsComponent() {
     const searchParams = useSearchParams();
     const url = searchParams.get('url');
-    const websiteStatusUrl = searchParams.get('websiteStatus');
-    const isCrawlableUrl = searchParams.get('isCrawlable');
-    const industryUrl = searchParams.get('industry');
+
+    const router = useRouter();
+    // const websiteStatusUrl = searchParams.get('websiteStatus');
+    // const isCrawlableUrl = searchParams.get('isCrawlable');
+    // const industryUrl = searchParams.get('industry');
     const [websiteStatus, setWebsiteStatus] = useState('');
     const [isCrawlable, setIsCrawlable] = useState('No');
     const [isLoading, setIsLoading] = useState(false);
@@ -29,12 +33,11 @@ function ResultsComponent() {
     const [imageList, setImageList] = useState([]);
 
     useEffect(() => {
-        if (websiteStatusUrl && isCrawlableUrl && industryUrl) {
-            setWebsiteStatus(websiteStatusUrl);
-            setIsCrawlable(isCrawlableUrl);
-            setIndustryClassification(industryUrl);
+        if (url) {
+            console.log('URL on the individual report page', url);
+            // const urlResults = 
         }
-    }, [websiteStatusUrl, isCrawlableUrl, industryUrl]);
+    }, [url]);
 
     // const fetchLogo = async (url: string) => {
     //     try {
@@ -58,6 +61,10 @@ function ResultsComponent() {
     //     }
     // }
 
+    const backToScrapeResults = () => {
+        router.push(`/scraperesults`);
+    }
+
     if (isLoading) {
         return (
             <div className='min-h-screen flex justify-center items-center'>
@@ -72,6 +79,13 @@ function ResultsComponent() {
     
     return (
         <div className='min-h-screen p-4'>
+            <Button 
+                className="text-md font-poppins-semibold bg-jungleGreen-700 text-dark-primaryTextColor dark:bg-jungleGreen-400 dark:text-primaryTextColor"
+                onClick={backToScrapeResults}
+            >
+                View overall summary report
+            </Button>
+
             <div className="mb-8 text-center">
                 <h1 className="mt-4 font-poppins-bold text-2xl text-jungleGreen-800 dark:text-dark-primaryTextColor">
                     Results of {url}

--- a/wee/frontend/src/app/(pages)/results/page.tsx
+++ b/wee/frontend/src/app/(pages)/results/page.tsx
@@ -96,15 +96,39 @@ function ResultsComponent() {
                             <TableCell>Industry</TableCell>
                             <TableCell>
                                 <Chip radius="sm" color="secondary" variant="flat">
-                                    {isCrawlable ? `${industryClassification?.label} - ${industryClassification?.score}` : 'N/A'}
-                                </Chip>                            
+                                    {isCrawlable ? `${industryClassification?.label}` : 'N/A'}
+                                </Chip>         
+                                <Chip 
+                                    radius="sm" 
+                                    color={ 
+                                        industryClassification?.score && (industryClassification?.score * 100) > 80 ? 'success' :
+                                        industryClassification?.score && (industryClassification?.score * 100) >= 50 ? 'warning' : 
+                                        'danger'
+                                    } 
+                                    variant="flat" 
+                                    className='ml-[2px] mt-2 sm:ml-2 sm:mt-0'
+                                >
+                                    {isCrawlable ? `${(industryClassification?.score ? (industryClassification?.score* 100).toFixed(2) : 0)}%` : '0%'}
+                                </Chip>                         
                             </TableCell>
                         </TableRow>
                         <TableRow key="4">
-                            <TableCell>Domain</TableCell>
+                            <TableCell>Domain match</TableCell>
                             <TableCell>
                                 <Chip radius="sm" color="secondary" variant="flat">
-                                    {isCrawlable ? `${domainClassification?.label} - ${domainClassification?.score}` : 'N/A'}
+                                    {isCrawlable ? `${domainClassification?.label}` : 'N/A'}
+                                </Chip>         
+                                <Chip 
+                                    radius="sm" 
+                                    color={ 
+                                        domainClassification?.score && (domainClassification?.score * 100) > 80 ? 'success' :
+                                        domainClassification?.score && (domainClassification?.score * 100) >= 50 ? 'warning' : 
+                                        'danger'
+                                    } 
+                                    variant="flat" 
+                                    className='ml-[2px] mt-2 sm:ml-2 sm:mt-0'
+                                >
+                                    {isCrawlable ? `${(domainClassification?.score ? (domainClassification?.score* 100).toFixed(2) : 0)}%` : '0%'}
                                 </Chip>   
                             </TableCell>
                         </TableRow>

--- a/wee/frontend/src/app/(pages)/scraperesults/page.tsx
+++ b/wee/frontend/src/app/(pages)/scraperesults/page.tsx
@@ -1,32 +1,19 @@
 'use client'
-import React, { useEffect, Suspense } from 'react';
+import React, { useEffect, Suspense, useRef } from 'react';
 import { FiSearch } from "react-icons/fi";
 import { SelectItem } from "@nextui-org/react";
-import { useSearchParams } from 'next/navigation';
 import WEEInput from '../../components/Util/Input';
 import WEESelect from '../../components/Util/Select';
 import WEEPagination from '../../components/Util/Pagination';
-import { Table, TableHeader, TableColumn, TableBody, TableRow, TableCell, Chip, Button } from "@nextui-org/react";
+import { TableHeader, TableColumn, TableBody, TableRow, TableCell, Chip, Button } from "@nextui-org/react";
 import { useRouter } from 'next/navigation';
-import Link from 'next/link'
 import WEETable from '../../components/Util/Table';
 import { useScrapingContext } from '../../context/ScrapingContext';
 import Scraping from '../../models/ScrapingModel';
 
-// interface CrawlableStatus {
-//     [url: string]: boolean;
-// }
-
-// interface Industry {
-//     url: string;
-//     industry : string;
-// }
-
 function ResultsComponent() {
-    // const searchParams = useSearchParams();
-    // const urls = searchParams.get('urls');
     const {urls, setUrls, results, setResults} = useScrapingContext();
-    // const [decodedUrls, setDecodedUrls] = React.useState<string[]>([]);
+    const processedUrls = useRef(new Set<string>());
     const [isLoading, setIsLoading] = React.useState(true);
 
     const [searchValue, setSearchValue] = React.useState("");
@@ -44,18 +31,13 @@ function ResultsComponent() {
         }
     
         return filteredUrls;
-      }, [results, searchValue]);
+    }, [results, searchValue]);
     
 
     const handleResultPage = (url:string, status:boolean, crawlable:boolean) => {
         router.push(`/results?url=${encodeURIComponent(url)}&websiteStatus=${encodeURIComponent(status)}&isCrawlable=${encodeURIComponent(crawlable)}`);
     };
-    
-    // arrays that holds results returned from API
-    // const [isCrawlable, setIsCrawlable] =  React.useState<CrawlableStatus>({});
-    // const [websiteStatus, setWebsiteStatus] = React.useState<boolean[]>([]);
-    // const [industryClassification, setIndustryClassification] = React.useState<Industry[]>([]);
-    
+        
     // Pagination
     const [page, setPage] = React.useState(1);
     const [resultsPerPage, setResultsPerPage] = React.useState(5);
@@ -75,20 +57,24 @@ function ResultsComponent() {
     }, [page, filteredItems, resultsPerPage]);
 
     useEffect(() => {
+        console.log('urls length: ', urls.length);
         if (urls && urls.length > 0) {
             urls.forEach((url) => {
-                console.log('Processing URL:', url);
-                getScrapingResults(url);
+                if (!processedUrls.current.has(url)) {
+                    console.log('Processing URL:', url);
+                    getScrapingResults(url);
+                    processedUrls.current.add(url);
+                }
             });
             // setUrls([]);
         }        
-    }, [urls])
+    }, [urls.length])
     
     useEffect(() => {      
         console.log("Results changed!!!!")  
-        if (urls.length == results.length) {
+        if (urls.length === results.length) {
             setIsLoading(false);    
-            setUrls([]);
+            // setUrls([]);
         }
     }, [results])
 

--- a/wee/frontend/src/app/(pages)/scraperesults/page.tsx
+++ b/wee/frontend/src/app/(pages)/scraperesults/page.tsx
@@ -10,47 +10,51 @@ import { Table, TableHeader, TableColumn, TableBody, TableRow, TableCell, Chip, 
 import { useRouter } from 'next/navigation';
 import Link from 'next/link'
 import WEETable from '../../components/Util/Table';
+import { useScrapingContext } from '../../context/ScrapingContext';
+import Scraping from '../../models/ScrapingModel';
 
-interface CrawlableStatus {
-    [url: string]: boolean;
-}
+// interface CrawlableStatus {
+//     [url: string]: boolean;
+// }
 
-interface Industry {
-    url: string;
-    industry : string;
-}
+// interface Industry {
+//     url: string;
+//     industry : string;
+// }
 
 function ResultsComponent() {
-    const searchParams = useSearchParams();
-    const urls = searchParams.get('urls');
-    const [decodedUrls, setDecodedUrls] = React.useState<string[]>([]);
+    // const searchParams = useSearchParams();
+    // const urls = searchParams.get('urls');
+    const {urls, setUrls, results, setResults} = useScrapingContext();
+    // const [decodedUrls, setDecodedUrls] = React.useState<string[]>([]);
     const [isLoading, setIsLoading] = React.useState(true);
 
     const [searchValue, setSearchValue] = React.useState("");
     const hasSearchFilter = Boolean(searchValue);
+    
+    const router = useRouter();
 
     const filteredItems = React.useMemo(() => {
-        let filteredUrls = [...decodedUrls];
+        let filteredUrls = [...results];
 
         if (hasSearchFilter) {
             filteredUrls = filteredUrls.filter((url) =>
-                url.toLowerCase().includes(searchValue.toLowerCase()),
+                url.url.toLowerCase().includes(searchValue.toLowerCase()),
             );
         }
     
         return filteredUrls;
-      }, [decodedUrls, searchValue]);
+      }, [results, searchValue]);
     
-    const router = useRouter();
 
     const handleResultPage = (url:string, status:boolean, crawlable:boolean) => {
         router.push(`/results?url=${encodeURIComponent(url)}&websiteStatus=${encodeURIComponent(status)}&isCrawlable=${encodeURIComponent(crawlable)}`);
     };
     
     // arrays that holds results returned from API
-    const [isCrawlable, setIsCrawlable] =  React.useState<CrawlableStatus>({});
-    const [websiteStatus, setWebsiteStatus] = React.useState<boolean[]>([]);
-    const [industryClassification, setIndustryClassification] = React.useState<Industry[]>([]);
+    // const [isCrawlable, setIsCrawlable] =  React.useState<CrawlableStatus>({});
+    // const [websiteStatus, setWebsiteStatus] = React.useState<boolean[]>([]);
+    // const [industryClassification, setIndustryClassification] = React.useState<Industry[]>([]);
     
     // Pagination
     const [page, setPage] = React.useState(1);
@@ -68,77 +72,39 @@ function ResultsComponent() {
         const end = start + resultsPerPage;
 
         return filteredItems.slice(start,end);
-    }, [page, filteredItems, resultsPerPage])
+    }, [page, filteredItems, resultsPerPage]);
 
     useEffect(() => {
-        if (urls) {
-            const decoded = decodeURIComponent(urls).split(',');
-            setDecodedUrls(decoded);
-            console.log(decoded); 
-
-            fetchIsCrawlingAllowed(urls);
-            fetchWebsiteStatus(urls);
-            // fetchIndustryClassifications(urls);
-        }
+        if (urls && urls.length > 0) {
+            urls.forEach((url) => {
+                console.log('Processing URL:', url);
+                getScrapingResults(url);
+            });
+            // setUrls([]);
+        }        
     }, [urls])
+    
+    useEffect(() => {      
+        console.log("Results changed!!!!")  
+        if (urls.length == results.length) {
+            setIsLoading(false);    
+            setUrls([]);
+        }
+    }, [results])
 
-    const fetchIsCrawlingAllowed = async (url: string) => {
+    const getScrapingResults = async (url: string) => {
         try {
-            const response = await fetch(`http://localhost:3000/api/isCrawlingAllowed?urls=${encodeURIComponent(url)}`);
-            const data = await response.json();
-            console.log('Crawling allowed', data);
-            setIsCrawlable(data);
+            const response = await fetch(`http://localhost:3000/api/scraper?url=${encodeURIComponent(url)}`);
+            const data = await response.json() as Scraping;
+            console.log('Response', data);
+            setResults((prevResults: Scraping[]) => [...prevResults, data]);
         }
-        catch (error) {
-            console.error('Error fetching whether website is crawlable:', error);
-        }
-    };
-
-    const fetchWebsiteStatus = async (url: string) => {
-        try {
-            const response = await fetch(`http://localhost:3000/api/status?urls=${encodeURIComponent(url)}`);
-            const data = await response.json();
-            console.log(data);
-            setWebsiteStatus(data);
-        }
-        catch (error) {
-            console.error('Error fetching website status:', error);
+        catch(error) {
+            console.error('Error when scraping website:', error);
         }
         finally {
-            setIsLoading(false);
+            // setIsLoading(false);
         }
-    };
-
-    const fetchIndustryClassifications = async (url: string) => {
-        try {
-            const response = await fetch(`http://localhost:3000/api/scrapeIndustry?urls=${encodeURIComponent(url)}`);
-            const data = await response.json();
-            console.log('industry classification', data);
-            data.forEach((item:any) => {
-                setIndustryClassification(prev => [
-                    ...prev, 
-                    { url: item.url, industry: item.metadata.industry }
-                ]);
-            })
-        }
-        catch (error) {
-            console.error('Error fetching industry classifications:', error);
-        }
-        finally {
-            setIsLoading(false);
-        }
-    }
-
-    if (isLoading) {
-        return (
-            <div className='min-h-screen flex justify-center items-center'>
-                <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-current border-e-transparent align-[-0.125em] text-surface motion-reduce:animate-[spin_1.5s_linear_infinite] dark:text-white" role="status">
-                    <span className="!absolute !-m-px !h-px !w-px !overflow-hidden !whitespace-nowrap !border-0 !p-0 ![clip:rect(0,0,0,0)]">
-                        Loading...
-                    </span>
-                </div>
-            </div>
-        );
     }
 
     const onSearchChange = (value: string) => {
@@ -152,6 +118,18 @@ function ResultsComponent() {
 
     const handleSummaryPage = () => {
         router.push(`/summaryreport`);
+    }
+
+    if (isLoading) {
+        return (
+            <div className='min-h-screen flex justify-center items-center'>
+                <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-current border-e-transparent align-[-0.125em] text-surface motion-reduce:animate-[spin_1.5s_linear_infinite] dark:text-white" role="status">
+                    <span className="!absolute !-m-px !h-px !w-px !overflow-hidden !whitespace-nowrap !border-0 !p-0 ![clip:rect(0,0,0,0)]">
+                        Loading...
+                    </span>
+                </div>
+            </div>
+        );
     }
 
     return (
@@ -245,16 +223,17 @@ function ResultsComponent() {
                     {items.map((item, index) => (
                         <TableRow key={index}>
                             <TableCell>
-                                <Link href={`/results?url=${encodeURIComponent(item)}&websiteStatus=${encodeURIComponent(websiteStatus[index])}&isCrawlable=${encodeURIComponent(isCrawlable[item])}`}>                               
+                                {/* <Link href={`/results?url=${encodeURIComponent(item)}&websiteStatus=${encodeURIComponent(websiteStatus[index])}&isCrawlable=${encodeURIComponent(isCrawlable[item])}`}>                               
                                     {item}
-                                </Link>
+                                </Link> */}
+                                {item.url}
                             </TableCell>
                             <TableCell className='text-center hidden sm:table-cell'>
-                                <Chip radius="sm" color={isCrawlable[item]? 'success' : 'warning'} variant="flat">{isCrawlable[item] ? 'Yes' : 'No'}</Chip>
+                                <Chip radius="sm" color={item.robots.isUrlScrapable? 'success' : 'warning'} variant="flat">{item.robots.isUrlScrapable ? 'Yes' : 'No'}</Chip>
                             </TableCell>
                             <TableCell className='text-center hidden sm:table-cell'>
                                 <Button className="font-poppins-semibold bg-jungleGreen-700 text-dark-primaryTextColor dark:bg-jungleGreen-400 dark:text-primaryTextColor"
-                                   onClick={() => handleResultPage(item, websiteStatus[index], isCrawlable[item])}
+                                //    onClick={() => handleResultPage(item, websiteStatus[index], isCrawlable[item])}
                                 >
                                     View
                                 </Button>

--- a/wee/frontend/src/app/(pages)/scraperesults/page.tsx
+++ b/wee/frontend/src/app/(pages)/scraperesults/page.tsx
@@ -93,9 +93,6 @@ function ResultsComponent() {
         catch(error) {
             console.error('Error when scraping website:', error);
         }
-        finally {
-            // setIsLoading(false);
-        }
     }
 
     const onSearchChange = (value: string) => {

--- a/wee/frontend/src/app/(pages)/scraperesults/page.tsx
+++ b/wee/frontend/src/app/(pages)/scraperesults/page.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/navigation';
 import WEETable from '../../components/Util/Table';
 import { useScrapingContext } from '../../context/ScrapingContext';
 import Scraping from '../../models/ScrapingModel';
+import Link from 'next/link';
 
 function ResultsComponent() {
     const {urls, setUrls, results, setResults} = useScrapingContext();
@@ -34,8 +35,8 @@ function ResultsComponent() {
     }, [results, searchValue]);
     
 
-    const handleResultPage = (url:string, status:boolean, crawlable:boolean) => {
-        router.push(`/results?url=${encodeURIComponent(url)}&websiteStatus=${encodeURIComponent(status)}&isCrawlable=${encodeURIComponent(crawlable)}`);
+    const handleResultPage = (url:string) => {
+        router.push(`/results?url=${encodeURIComponent(url)}`);
     };
         
     // Pagination
@@ -66,15 +67,19 @@ function ResultsComponent() {
                     processedUrls.current.add(url);
                 }
             });
-            // setUrls([]);
-        }        
+        }  
+        else {
+            // allows to naviagte back to this page without rescraping the urls
+            setIsLoading(false);
+        }      
     }, [urls.length])
     
     useEffect(() => {      
         console.log("Results changed!!!!")  
         if (urls.length === results.length) {
-            setIsLoading(false);    
-            // setUrls([]);
+            setIsLoading(false);  
+            // allows to naviagte back to this page without rescraping the urls  
+            setUrls([]);
         }
     }, [results])
 
@@ -209,17 +214,16 @@ function ResultsComponent() {
                     {items.map((item, index) => (
                         <TableRow key={index}>
                             <TableCell>
-                                {/* <Link href={`/results?url=${encodeURIComponent(item)}&websiteStatus=${encodeURIComponent(websiteStatus[index])}&isCrawlable=${encodeURIComponent(isCrawlable[item])}`}>                               
-                                    {item}
-                                </Link> */}
-                                {item.url}
+                                <Link href={`/results?url=${encodeURIComponent(item.url)}`}>                               
+                                    {item.url}
+                                </Link>
                             </TableCell>
                             <TableCell className='text-center hidden sm:table-cell'>
                                 <Chip radius="sm" color={item.robots.isUrlScrapable? 'success' : 'warning'} variant="flat">{item.robots.isUrlScrapable ? 'Yes' : 'No'}</Chip>
                             </TableCell>
                             <TableCell className='text-center hidden sm:table-cell'>
                                 <Button className="font-poppins-semibold bg-jungleGreen-700 text-dark-primaryTextColor dark:bg-jungleGreen-400 dark:text-primaryTextColor"
-                                //    onClick={() => handleResultPage(item, websiteStatus[index], isCrawlable[item])}
+                                   onClick={() => handleResultPage(item.url)}
                                 >
                                     View
                                 </Button>

--- a/wee/frontend/src/app/context/ScrapingContext.tsx
+++ b/wee/frontend/src/app/context/ScrapingContext.tsx
@@ -1,8 +1,9 @@
 import { createContext, useContext } from "react";
+import Scraping from "../models/ScrapingModel";
 
 interface ScrapingContextType {
-    results: any[];
-    setResults: (data: any[]) => void;
+    results: Scraping[];
+    setResults: (data: Scraping[]) => void;
     urls: string[];
     setUrls: (data: string[]) => void;
     test: string;

--- a/wee/frontend/src/app/context/ScrapingContext.tsx
+++ b/wee/frontend/src/app/context/ScrapingContext.tsx
@@ -1,0 +1,21 @@
+import { createContext, useContext } from "react";
+
+interface ScrapingContextType {
+    results: any[];
+    setResults: (data: any[]) => void;
+    urls: string[];
+    setUrls: (data: string[]) => void;
+    test: string;
+}
+
+const ScrapingContext = createContext<ScrapingContextType | undefined>(undefined);
+
+export const useScrapingContext = () => {
+    const context = useContext(ScrapingContext);
+    if (!context) {
+        throw new Error("useScrapingContext must be used within a ScrapingProvider");
+    }
+    return context;
+};
+
+export default ScrapingContext;

--- a/wee/frontend/src/app/context/ScrapingContext.tsx
+++ b/wee/frontend/src/app/context/ScrapingContext.tsx
@@ -3,7 +3,7 @@ import Scraping from "../models/ScrapingModel";
 
 interface ScrapingContextType {
     results: Scraping[];
-    setResults: (data: Scraping[]) => void;
+    setResults: (update: (prevResults: Scraping[]) => Scraping[]) => void;
     urls: string[];
     setUrls: (data: string[]) => void;
 }

--- a/wee/frontend/src/app/context/ScrapingContext.tsx
+++ b/wee/frontend/src/app/context/ScrapingContext.tsx
@@ -6,7 +6,6 @@ interface ScrapingContextType {
     setResults: (data: Scraping[]) => void;
     urls: string[];
     setUrls: (data: string[]) => void;
-    test: string;
 }
 
 const ScrapingContext = createContext<ScrapingContextType | undefined>(undefined);

--- a/wee/frontend/src/app/models/ScrapingModel.ts
+++ b/wee/frontend/src/app/models/ScrapingModel.ts
@@ -26,7 +26,7 @@ interface IndustryClassification {
     };
 }
 
-export interface Scraping {
+export default interface Scraping {
     url: string;
     domainStatus: string;
     robots: Robots;

--- a/wee/frontend/src/app/models/ScrapingModel.ts
+++ b/wee/frontend/src/app/models/ScrapingModel.ts
@@ -1,0 +1,38 @@
+interface Robots {
+    baseUrl: string;
+    allowedPaths: string[];
+    disallowedPaths: string[];
+    isUrlScrapable: boolean;
+    isBaseUrlAllowed: boolean;
+}
+
+interface Metadata {
+    title: string;
+    description: string;
+    keywords: string;
+    ogTitle: string;
+    ogDescription: string;
+    ogImage: string;
+}
+
+interface IndustryClassification {
+    metadataClass: {
+        label: string;
+        score: number;
+    };
+    domainClass: {
+        label: string;
+        score: number;
+    };
+}
+
+export interface Scraping {
+    url: string;
+    domainStatus: string;
+    robots: Robots;
+    metadata: Metadata;
+    industryClassification: IndustryClassification;
+    logo: string;
+    images: string[];
+    slogan: string;
+}

--- a/wee/frontend/src/app/provider/ScrapingProvider.tsx
+++ b/wee/frontend/src/app/provider/ScrapingProvider.tsx
@@ -1,8 +1,9 @@
 import React, { useState, ReactNode } from "react";
 import ScrapingContext from "../context/ScrapingContext";
+import Scraping from "../models/ScrapingModel";
 
 export const ScrapingProvider = ({children} : {children: ReactNode}) => {
-    const [results, setResults] = useState<any[]>([]);
+    const [results, setResults] = useState<Scraping[]>([]);
     const [urls, setUrls] = useState<string[]>(['']);
     const test = 'Test the context';
 

--- a/wee/frontend/src/app/provider/ScrapingProvider.tsx
+++ b/wee/frontend/src/app/provider/ScrapingProvider.tsx
@@ -8,7 +8,7 @@ export const ScrapingProvider = ({children} : {children: ReactNode}) => {
     const test = 'Test the context';
 
     return (
-        <ScrapingContext.Provider value={{results, setResults, urls, setUrls, test}}>
+        <ScrapingContext.Provider value={{results, setResults, urls, setUrls}}>
             {children}
         </ScrapingContext.Provider>
     )

--- a/wee/frontend/src/app/provider/ScrapingProvider.tsx
+++ b/wee/frontend/src/app/provider/ScrapingProvider.tsx
@@ -1,0 +1,14 @@
+import React, { useState, ReactNode } from "react";
+import ScrapingContext from "../context/ScrapingContext";
+
+export const ScrapingProvider = ({children} : {children: ReactNode}) => {
+    const [results, setResults] = useState<any[]>([]);
+    const [urls, setUrls] = useState<string[]>(['']);
+    const test = 'Test the context';
+
+    return (
+        <ScrapingContext.Provider value={{results, setResults, urls, setUrls, test}}>
+            {children}
+        </ScrapingContext.Provider>
+    )
+}

--- a/wee/frontend/src/app/providers.tsx
+++ b/wee/frontend/src/app/providers.tsx
@@ -1,10 +1,13 @@
 'use client'
 import { ThemeProvider } from "next-themes"
+import { ScrapingProvider } from "./provider/ScrapingProvider"
 
 export function Providers({children}: {children: React.ReactNode}) {
     return (
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-            {children}
+            <ScrapingProvider>
+                {children}
+            </ScrapingProvider>
         </ThemeProvider>
     )
 }


### PR DESCRIPTION
## Description
Set up overall context + provider that pages can use - thus avoiding data to be passed in url
Integrated (Home page to scrape result page and from scrape result page to individual report page)
Written unit testing

## Changes Made
- Urls entered in home page are stored in urls array in the context
- Endpoint is called in scraping result page and stored in results array in the context
- Added a back button to individual report page -> now the user can navigate back to the scrape result page without it scraping again

## Screenshots (if applicable)
![image](https://github.com/COS301-SE-2024/Web-Exploration-Engine/assets/126988676/02c09633-5652-4574-a9d3-27832a0597ce)

Homepage to scrape result page: (pagination and searching still work)
![image](https://github.com/COS301-SE-2024/Web-Exploration-Engine/assets/126988676/510f2703-56cf-4284-9549-e7f68c99f7de)

Scrape result page to individual report page:
![image](https://github.com/COS301-SE-2024/Web-Exploration-Engine/assets/126988676/b824ee1d-0143-42b0-99e5-2fab17793038)

(Clicking on the back button, the user should be navigated back to the scrape result page but the endpoint won't be called again)

## Related Issues
#103 #119 #131 #134

## Checklist
- [x] I have tested this code locally
- [x] I have reviewed the code for readability and maintainability
- [x] I have added appropriate documentation or updated existing documentation
- [x] I have ensured that my changes follow the project's coding conventions
- [ ] I have performed additional steps, if required [e.g., database migrations, configuration changes, etc.]

## Additional Notes
There is still some outstanding frontend improvements
