### PR TITLE
Feature/improve scrape results loading

### DIFF
--- a/wee/frontend/src/app/(pages)/scraperesults/page.tsx
+++ b/wee/frontend/src/app/(pages)/scraperesults/page.tsx
@@ -5,7 +5,7 @@ import { SelectItem } from "@nextui-org/react";
 import WEEInput from '../../components/Util/Input';
 import WEESelect from '../../components/Util/Select';
 import WEEPagination from '../../components/Util/Pagination';
-import { TableHeader, TableColumn, TableBody, TableRow, TableCell, Chip, Button } from "@nextui-org/react";
+import { TableHeader, TableColumn, TableBody, TableRow, TableCell, Chip, Button, Spinner } from "@nextui-org/react";
 import { useRouter } from 'next/navigation';
 import WEETable from '../../components/Util/Table';
 import { useScrapingContext } from '../../context/ScrapingContext';
@@ -60,7 +60,7 @@ function ResultsComponent() {
 
     useEffect(() => {
         console.log('urls length: ', urls.length);
-        if (urls && urls.length > 0) {
+        if (urls && urls.length > 0 && urls.length !== results.length) {
             urls.forEach((url) => {
                 if (!processedUrls.current.has(url)) {
                     console.log('Processing URL:', url);
@@ -116,17 +116,6 @@ function ResultsComponent() {
         router.push(`/summaryreport`);
     }
 
-    if (isLoading) {
-        return (
-            <div className='min-h-screen flex justify-center items-center'>
-                <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-current border-e-transparent align-[-0.125em] text-surface motion-reduce:animate-[spin_1.5s_linear_infinite] dark:text-white" role="status">
-                    <span className="!absolute !-m-px !h-px !w-px !overflow-hidden !whitespace-nowrap !border-0 !p-0 ![clip:rect(0,0,0,0)]">
-                        Loading...
-                    </span>
-                </div>
-            </div>
-        );
-    }
 
     return (
         <div className='p-4'>            
@@ -187,17 +176,29 @@ function ResultsComponent() {
             <WEETable 
                 aria-label="Scrape result table"
                 bottomContent={
-                    <div className="flex w-full justify-center">
-                        <WEEPagination 
-                            loop 
-                            showControls 
-                            color="stone" 
-                            page={page}
-                            total={pages}
-                            onChange={(page) => setPage(page)}
-                            aria-label="Pagination"
-                        />
-                    </div>
+                    <>
+                    
+                        {isLoading ? (
+                            <div className="flex w-full justify-center">
+                                <Spinner color="white" />
+                            </div>
+                        ) : null}
+
+                        {results.length > 0 && 
+                            <div className="flex w-full justify-center">
+                                <WEEPagination 
+                                    loop 
+                                    showControls 
+                                    color="stone" 
+                                    page={page}
+                                    total={pages}
+                                    onChange={(page) => setPage(page)}
+                                    aria-label="Pagination"
+                                />
+                            </div>
+                        }
+                    </>
+                  
                 }
                 classNames={{
                     wrapper: "min-h-[222px]",
@@ -215,7 +216,9 @@ function ResultsComponent() {
                     </TableColumn>
                 </TableHeader>
 
-                <TableBody>
+                <TableBody
+                    emptyContent={"There is no results to be displayed"}
+                >
                     {items.map((item, index) => (
                         <TableRow key={index}>
                             <TableCell>

--- a/wee/frontend/src/app/(pages)/scraperesults/page.tsx
+++ b/wee/frontend/src/app/(pages)/scraperesults/page.tsx
@@ -180,7 +180,7 @@ function ResultsComponent() {
                     
                         {isLoading ? (
                             <div className="flex w-full justify-center">
-                                <Spinner color="white" />
+                                <Spinner color='default'/>
                             </div>
                         ) : null}
 
@@ -245,8 +245,9 @@ function ResultsComponent() {
                 Summary
             </h1>
             <Button 
-                className="text-md font-poppins-semibold bg-jungleGreen-700 text-dark-primaryTextColor dark:bg-jungleGreen-400 dark:text-primaryTextColor"
+                className="text-md font-poppins-semibold bg-jungleGreen-700 text-dark-primaryTextColor dark:bg-jungleGreen-400 dark:text-primaryTextColor disabled:bg-jungleGreen-600 disabled:dark:bg-jungleGreen-300 disabled:cursor-wait"
                 onClick={handleSummaryPage}
+                disabled={isLoading}
             >
                 View overall summary report
             </Button>


### PR DESCRIPTION
## Description
Load results in one at a time as they are being scraper
Disable summary report button until all results are loaded in

## Changes Made
Load results in one at a time as they are being scraper
Disable summary report button until all results are loaded in

## Screenshots (if applicable)
![image](https://github.com/COS301-SE-2024/Web-Exploration-Engine/assets/126988676/140e0329-1590-40be-9e41-c7245aca8fd4)

## Related Issues
#140 

## Checklist
- [x] I have tested this code locally
- [x] I have reviewed the code for readability and maintainability
- [ ] I have added appropriate documentation or updated existing documentation
- [x] I have ensured that my changes follow the project's coding conventions
- [ ] I have performed additional steps, if required [e.g., database migrations, configuration changes, etc.]

## Additional Notes
[Include any additional notes or context relevant to the pull request]
