### PR TITLE
Improve mobile view for piechart legend

### DIFF
--- a/wee/frontend/src/app/(pages)/summaryreport/page.tsx
+++ b/wee/frontend/src/app/(pages)/summaryreport/page.tsx
@@ -144,7 +144,13 @@ export default function SummaryReport() {
                             placement="top" 
                         />
                     </h3>
-                    <PieChart dataLabel={industries} dataSeries={industryPercentages}/>
+
+                    <span className='sm:hidden'>
+                        <PieChart dataLabel={industries} dataSeries={industryPercentages} legendPosition={"bottom"}/>
+                    </span>
+                    <span className='hidden sm:block'>
+                        <PieChart dataLabel={industries} dataSeries={industryPercentages} legendPosition={"right"}/>
+                    </span>
                 </div>
 
                 <div className='bg-zinc-200 dark:bg-zinc-700 p-4 rounded-xl md:col-span-1'>

--- a/wee/frontend/src/app/components/Graphs/PieChart.tsx
+++ b/wee/frontend/src/app/components/Graphs/PieChart.tsx
@@ -8,7 +8,11 @@ import { ChartColours, DarkChartColours } from "./colours";
 
 const Chart = dynamic(() => import("react-apexcharts"), { ssr: false });
 
-export function PieChart({dataLabel, dataSeries}: IChart) {
+interface IChartExtended extends IChart {
+    legendPosition: 'bottom' | 'right';
+}
+
+export function PieChart({dataLabel, dataSeries, legendPosition}: IChartExtended) {
     const { theme } = useTheme();
     const [options, setOptions] = useState<ApexOptions>({
         chart: {
@@ -32,7 +36,7 @@ export function PieChart({dataLabel, dataSeries}: IChart) {
             mode: theme === 'dark' ? 'dark' : 'light'
         },
         legend: {
-          position: 'right',
+          position: legendPosition,
           horizontalAlign: 'left',
         },
   


### PR DESCRIPTION
## Description
The pie chart legend should be at the bottom of the chart on mobile view, otherwise it should be to the right of the chart.

## Changes Made
The pie chart legend should be at the bottom of the chart on mobile view, otherwise it should be to the right of the chart.

## Screenshots (if applicable)
Instead of this:
![image](https://github.com/COS301-SE-2024/Web-Exploration-Engine/assets/126988676/2f7c4952-7e8a-4d2f-9b5e-20f683980596)

To this:
![image](https://github.com/COS301-SE-2024/Web-Exploration-Engine/assets/126988676/74d5d0e8-d300-4c96-ac2e-387f86661e45)
![image](https://github.com/COS301-SE-2024/Web-Exploration-Engine/assets/126988676/875180c7-7b74-4756-9e1f-7313095bfd5b)


## Related Issues
#178 

## Checklist
- [x] I have tested this code locally
- [x] I have reviewed the code for readability and maintainability
- [ ] I have added appropriate documentation or updated existing documentation
- [x] I have ensured that my changes follow the project's coding conventions
- [ ] I have performed additional steps, if required [e.g., database migrations, configuration changes, etc.]

## Additional Notes
[Include any additional notes or context relevant to the pull request]
