### PR TITLE
remove cypress config from wee folder

### DIFF
--- a/wee/cypress.config.ts
+++ b/wee/cypress.config.ts
@@ -1,9 +1,0 @@
-import { defineConfig } from "cypress";
-
-export default defineConfig({
-  e2e: {
-    setupNodeEvents(on, config) {
-      // implement node event listeners here
-    },
-  },
-});


### PR DESCRIPTION
## Description
Fix failing build on cypress integration branch

## Changes Made
- remove the cypress config file from wee folder - prevented nx from building


## Checklist
- [ ] I have tested this code locally
- [ ] I have reviewed the code for readability and maintainability
- [ ] I have added appropriate documentation or updated existing documentation
- [ ] I have ensured that my changes follow the project's coding conventions
- [ ] I have performed additional steps, if required [e.g., database migrations, configuration changes, etc.]
