### PR TITLE
removed getPositiveNegativeWords from sentiment analysis

### DIFF
--- a/wee/webscraper/src/sentiment-analysis/sentiment-analysis.service.ts
+++ b/wee/webscraper/src/sentiment-analysis/sentiment-analysis.service.ts
@@ -17,13 +17,15 @@ export class SentimentAnalysisService {
   async classifySentiment(url: string, metadata: Metadata): Promise<SentimentClassification> {
     try {
       const sentimentAnalysis = await this.sentimentAnalysis(metadata);
-      const { positiveWords, negativeWords } = await this.getPositiveNegativeWords(metadata);
+      // const { positiveWords, negativeWords } = await this.getPositiveNegativeWords(metadata);
       const emotions = await this.analyzeEmotions(metadata);
 
       return {
         sentimentAnalysis,
-        positiveWords,
-        negativeWords,
+        positiveWords: [], 
+        negativeWords: [],
+        // positiveWords,
+        // negativeWords,
         emotions,
       };
     } catch (error) {
@@ -100,91 +102,91 @@ export class SentimentAnalysisService {
     }
   }
 
-  async getPositiveNegativeWords(metadata: Metadata): Promise<{ positiveWords: string[], negativeWords: string[] }> {
-    const inputText = `${metadata.title || ''} ${metadata.description || ''} ${metadata.keywords || ''}`.trim();
+  // async getPositiveNegativeWords(metadata: Metadata): Promise<{ positiveWords: string[], negativeWords: string[] }> {
+  //   const inputText = `${metadata.title || ''} ${metadata.description || ''} ${metadata.keywords || ''}`.trim();
     
-    console.log(`Input text for word-level sentiment analysis: "${inputText}"`);
+  //   console.log(`Input text for word-level sentiment analysis: "${inputText}"`);
     
-    if (!inputText) {
-      console.log('Input text is empty, returning empty word lists.');
-      return { positiveWords: [], negativeWords: [] };
-    }
+  //   if (!inputText) {
+  //     console.log('Input text is empty, returning empty word lists.');
+  //     return { positiveWords: [], negativeWords: [] };
+  //   }
     
-    try {
-      const tokens: string[] = inputText.split(/\s+/).filter(token => token.length >= 4);
-      const uniqueTokens: string[] = Array.from(new Set(tokens));
+  //   try {
+  //     const tokens: string[] = inputText.split(/\s+/).filter(token => token.length >= 4);
+  //     const uniqueTokens: string[] = Array.from(new Set(tokens));
   
-      if (uniqueTokens.length === 0) {
-        //console.log('No tokens to analyze, returning empty word lists.');
-        return { positiveWords: [], negativeWords: [] };
-      }
+  //     if (uniqueTokens.length === 0) {
+  //       //console.log('No tokens to analyze, returning empty word lists.');
+  //       return { positiveWords: [], negativeWords: [] };
+  //     }
   
-      const BATCH_SIZE = 50;
-      const batches: string[][] = [];
-      for (let i = 0; i < uniqueTokens.length; i += BATCH_SIZE) {
-        batches.push(uniqueTokens.slice(i, i + BATCH_SIZE));
-      }
+  //     const BATCH_SIZE = 50;
+  //     const batches: string[][] = [];
+  //     for (let i = 0; i < uniqueTokens.length; i += BATCH_SIZE) {
+  //       batches.push(uniqueTokens.slice(i, i + BATCH_SIZE));
+  //     }
   
-      const positiveWords: string[] = [];
-      const negativeWords: string[] = [];
+  //     const positiveWords: string[] = [];
+  //     const negativeWords: string[] = [];
   
-      for (const batch of batches) {
-        const response = await axios.post(
-          this.HUGGING_FACE_TOKEN_CLASSIFICATION_API_URL,
-          { inputs: batch },
-          {
-            headers: {
-              Authorization: `Bearer ${this.HUGGING_FACE_API_TOKEN}`,
-              'Content-Type': 'application/json',
-            },
-          }
-        );
+  //     for (const batch of batches) {
+  //       const response = await axios.post(
+  //         this.HUGGING_FACE_TOKEN_CLASSIFICATION_API_URL,
+  //         { inputs: batch },
+  //         {
+  //           headers: {
+  //             Authorization: `Bearer ${this.HUGGING_FACE_API_TOKEN}`,
+  //             'Content-Type': 'application/json',
+  //           },
+  //         }
+  //       );
   
-        console.log(`Response for batch ${batch}:`, response.data);
+  //       console.log(`Response for batch ${batch}:`, response.data);
   
-        if (response.data && Array.isArray(response.data)) {
-          for (const [index, tokenResponse] of response.data.entries()) {
-            const token = batch[index];
-            if (Array.isArray(tokenResponse)) {
-              let maxScore = -1;
-              let sentimentLabel = '';
+  //       if (response.data && Array.isArray(response.data)) {
+  //         for (const [index, tokenResponse] of response.data.entries()) {
+  //           const token = batch[index];
+  //           if (Array.isArray(tokenResponse)) {
+  //             let maxScore = -1;
+  //             let sentimentLabel = '';
               
-              tokenResponse.forEach((result: any) => {
-                if (result.score > maxScore) {
-                  maxScore = result.score;
-                  sentimentLabel = result.label;
-                }
-              });
+  //             tokenResponse.forEach((result: any) => {
+  //               if (result.score > maxScore) {
+  //                 maxScore = result.score;
+  //                 sentimentLabel = result.label;
+  //               }
+  //             });
   
-              if (maxScore > this.SCORE_THRESHOLD) {
-                switch (sentimentLabel) {
-                  case '5 stars':
-                  case '4 stars':
-                    positiveWords.push(token);
-                    break;
-                  case '1 star':
-                  case '2 stars':
-                    negativeWords.push(token);
-                    break;
-                  default:
-                    console.log(`Token with neutral/unknown sentiment: ${token}`);
-                }
-              }
-            } else {
-              console.log(`Unexpected response format for token: ${token}`);
-            }
-          }
-        } else {
-          throw new Error('Unexpected response format from token classification API');
-        }
-      }
+  //             if (maxScore > this.SCORE_THRESHOLD) {
+  //               switch (sentimentLabel) {
+  //                 case '5 stars':
+  //                 case '4 stars':
+  //                   positiveWords.push(token);
+  //                   break;
+  //                 case '1 star':
+  //                 case '2 stars':
+  //                   negativeWords.push(token);
+  //                   break;
+  //                 default:
+  //                   console.log(`Token with neutral/unknown sentiment: ${token}`);
+  //               }
+  //             }
+  //           } else {
+  //             console.log(`Unexpected response format for token: ${token}`);
+  //           }
+  //         }
+  //       } else {
+  //         throw new Error('Unexpected response format from token classification API');
+  //       }
+  //     }
   
-      return { positiveWords, negativeWords };
-    } catch (error) {
-      console.error('Error during word-level sentiment analysis:', error.message);
-      return { positiveWords: [], negativeWords: [] };
-    }
-  }
+  //     return { positiveWords, negativeWords };
+  //   } catch (error) {
+  //     console.error('Error during word-level sentiment analysis:', error.message);
+  //     return { positiveWords: [], negativeWords: [] };
+  //   }
+  // }
   async analyzeEmotions(metadata: Metadata): Promise<{ [emotion: string]: number }> {
     const inputText = `${metadata.title || ''} ${metadata.description || ''} ${metadata.keywords || ''}`.trim();
   

--- a/wee/webscraper/src/sentiment-analysis/sentiment-analysis.spec.ts
+++ b/wee/webscraper/src/sentiment-analysis/sentiment-analysis.spec.ts
@@ -45,14 +45,16 @@ describe('SentimentAnalysisService', () => {
       const emotions = { happy: 0.9, sad: 0.1 };
 
       jest.spyOn(service, 'sentimentAnalysis').mockResolvedValue(sentimentAnalysisResult);
-      jest.spyOn(service, 'getPositiveNegativeWords').mockResolvedValue({ positiveWords, negativeWords });
+      // jest.spyOn(service, 'getPositiveNegativeWords').mockResolvedValue({ positiveWords, negativeWords });
       jest.spyOn(service, 'analyzeEmotions').mockResolvedValue(emotions);
 
       const result = await service.classifySentiment('', metadata);
       expect(result).toEqual({
         sentimentAnalysis: sentimentAnalysisResult,
-        positiveWords,
-        negativeWords,
+        // positiveWords,
+        // negativeWords,
+        positiveWords: [],
+        negativeWords: [],
         emotions,
       });
     });
@@ -66,7 +68,7 @@ describe('SentimentAnalysisService', () => {
       };
 
       jest.spyOn(service, 'sentimentAnalysis').mockRejectedValue(new Error('Network error'));
-      jest.spyOn(service, 'getPositiveNegativeWords').mockRejectedValue(new Error('Network error'));
+      // jest.spyOn(service, 'getPositiveNegativeWords').mockRejectedValue(new Error('Network error'));
       jest.spyOn(service, 'analyzeEmotions').mockRejectedValue(new Error('Network error'));
 
       const result = await service.classifySentiment('', metadata);
@@ -134,90 +136,90 @@ describe('SentimentAnalysisService', () => {
     });
   });
 
-  describe('getPositiveNegativeWords', () => {
-    it('should return positive and negative words successfully', async () => {
-      const metadata: Metadata = {
-        title: 'Test Title',
-        description: 'Test Description',
-        keywords: 'great amazing bad terrible',
-        ogTitle: '',
-        ogDescription: '',
-        ogImage: ''
-      };
+  // describe('getPositiveNegativeWords', () => {
+  //   it('should return positive and negative words successfully', async () => {
+  //     const metadata: Metadata = {
+  //       title: 'Test Title',
+  //       description: 'Test Description',
+  //       keywords: 'great amazing bad terrible',
+  //       ogTitle: '',
+  //       ogDescription: '',
+  //       ogImage: ''
+  //     };
   
-      const positiveWords = ['Test'];
-      const negativeWords = [];
+  //     const positiveWords = ['Test'];
+  //     const negativeWords = [];
   
-      mockedAxios.post.mockResolvedValue({
-        data: [[
-          { label: '5 stars', score: 0.9 },
-          { label: '1 star', score: 0.8 }
-        ]]
-      });
+  //     mockedAxios.post.mockResolvedValue({
+  //       data: [[
+  //         { label: '5 stars', score: 0.9 },
+  //         { label: '1 star', score: 0.8 }
+  //       ]]
+  //     });
   
-      const result = await service.getPositiveNegativeWords(metadata);
-      expect(result).toEqual({ positiveWords, negativeWords });
-    });
+  //     const result = await service.getPositiveNegativeWords(metadata);
+  //     expect(result).toEqual({ positiveWords, negativeWords });
+  //   });
   
-    it('should handle neutral/unknown sentiment and not include them in the lists', async () => {
-      const metadata: Metadata = {
-        title: 'Neutral Test',
-        description: 'Neutral Description',
-        keywords: 'neutral unknown',
-        ogTitle: '',
-        ogDescription: '',
-        ogImage: ''
-      };
+  //   it('should handle neutral/unknown sentiment and not include them in the lists', async () => {
+  //     const metadata: Metadata = {
+  //       title: 'Neutral Test',
+  //       description: 'Neutral Description',
+  //       keywords: 'neutral unknown',
+  //       ogTitle: '',
+  //       ogDescription: '',
+  //       ogImage: ''
+  //     };
   
-      mockedAxios.post.mockResolvedValue({
-        data: [
-          [
-            { label: '3 stars', score: 0.5 }, 
-            { label: '3 stars', score: 0.4 }  
-          ]
-        ]
-      });
+  //     mockedAxios.post.mockResolvedValue({
+  //       data: [
+  //         [
+  //           { label: '3 stars', score: 0.5 }, 
+  //           { label: '3 stars', score: 0.4 }  
+  //         ]
+  //       ]
+  //     });
   
-      const result = await service.getPositiveNegativeWords(metadata);
-      expect(result).toEqual({ positiveWords: [], negativeWords: [] });
-    });
+  //     const result = await service.getPositiveNegativeWords(metadata);
+  //     expect(result).toEqual({ positiveWords: [], negativeWords: [] });
+  //   });
   
-    it('should handle unexpected response format from token classification API', async () => {
-      const metadata: Metadata = {
-        title: 'Unexpected Format Test',
-        description: 'Testing unexpected response format',
-        keywords: 'unexpected response',
-        ogTitle: '',
-        ogDescription: '',
-        ogImage: ''
-      };
+  //   it('should handle unexpected response format from token classification API', async () => {
+  //     const metadata: Metadata = {
+  //       title: 'Unexpected Format Test',
+  //       description: 'Testing unexpected response format',
+  //       keywords: 'unexpected response',
+  //       ogTitle: '',
+  //       ogDescription: '',
+  //       ogImage: ''
+  //     };
   
-      mockedAxios.post.mockResolvedValue({
-        data: {} 
-      });
+  //     mockedAxios.post.mockResolvedValue({
+  //       data: {} 
+  //     });
   
-      const result = await service.getPositiveNegativeWords(metadata);
-      expect(result).toEqual({ positiveWords: [], negativeWords: [] });
-    });
+  //     const result = await service.getPositiveNegativeWords(metadata);
+  //     expect(result).toEqual({ positiveWords: [], negativeWords: [] });
+  //   });
   
-    it('should handle empty batch response gracefully', async () => {
-      const metadata: Metadata = {
-        title: 'Empty Batch Test',
-        description: 'Testing empty batch response',
-        keywords: 'empty batch',
-        ogTitle: '',
-        ogDescription: '',
-        ogImage: ''
-      };
+  //   it('should handle empty batch response gracefully', async () => {
+  //     const metadata: Metadata = {
+  //       title: 'Empty Batch Test',
+  //       description: 'Testing empty batch response',
+  //       keywords: 'empty batch',
+  //       ogTitle: '',
+  //       ogDescription: '',
+  //       ogImage: ''
+  //     };
   
-      mockedAxios.post.mockResolvedValue({
-        data: [] 
-      });
+  //     mockedAxios.post.mockResolvedValue({
+  //       data: [] 
+  //     });
   
-      const result = await service.getPositiveNegativeWords(metadata);
-      expect(result).toEqual({ positiveWords: [], negativeWords: [] });
-    });
-  });
+  //     const result = await service.getPositiveNegativeWords(metadata);
+  //     expect(result).toEqual({ positiveWords: [], negativeWords: [] });
+  //   });
+  // });
   
 
   describe('analyzeEmotions', () => {


### PR DESCRIPTION
## Description
Removed getPositiveNegativeWords from sentiment analysis in an attempt to temporarily fix the hugging face time out issue for demo 3.

## Changes Made
- Commented out the getPositiveNegativeWords in the sentiment analysis service
- Commented out and fixed the respective testing

## Screenshots (if applicable)
Just return a empty list of positive and negative words
![image](https://github.com/user-attachments/assets/acfaed4e-2939-4e02-b2c8-33ef447861c7)

How its then handled in the frontend:
![image](https://github.com/user-attachments/assets/8201a084-d781-40e8-9d4b-6ca26d26fe93)

## Related Issues
#317 

## Checklist
- [x] I have tested this code locally
- [x] I have reviewed the code for readability and maintainability
- [ ] I have added appropriate documentation or updated existing documentation
- [ ] I have ensured that my changes follow the project's coding conventions
- [ ] I have performed additional steps, if required [e.g., database migrations, configuration changes, etc.]

## Additional Notes
[Include any additional notes or context relevant to the pull request]
