### PR TITLE
don't display the radar graphs on mobile viewport

### DIFF
--- a/wee/frontend/specs/unit/SummaryReport.spec.tsx
+++ b/wee/frontend/specs/unit/SummaryReport.spec.tsx
@@ -139,6 +139,19 @@ describe('SummaryReport Page', () => {
     expect(screen.getByText('100 sec')).toBeInTheDocument(); // Average Time
   });
 
+  it("don't display radar graphs on mobile phone", () => {
+    global.innerWidth = 250;
+    global.dispatchEvent(new Event('resize'));
+
+    render(<SummaryReport />);
+
+    expect(screen.getByText('Sorry, the metadata radar graph is not available on mobile devices')).toBeInTheDocument();
+    expect(screen.getByText('Sorry, the domain radar graph is not available on mobile devices')).toBeInTheDocument();
+
+    expect(screen.queryByTestId('metaRadar')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('domainRadar')).not.toBeInTheDocument();
+  });
+
   it('should call jsPDF and download the PDF when download button is clicked', async () => {
     render(<SummaryReport />);
     const dropdownButton = screen.getByRole('button', { name: /export\/save/i });

--- a/wee/frontend/specs/unit/SummaryReport.spec.tsx
+++ b/wee/frontend/specs/unit/SummaryReport.spec.tsx
@@ -81,6 +81,39 @@ describe('SummaryReport Page', () => {
   const mockSummaryReport = {
     domainStatus: [200, 404],
     domainErrorStatus: 1,
+    domainRadar: {
+      categories: [
+        "Finance and Banking",
+        "Marine and Shipping",
+        "Logistics and Supply Chain Management",
+        "Entertainment and Media",
+        "Arts and Culture"
+      ],
+      series: [
+        {
+            name: "https://www.nedbank.co.za",
+            data: [
+                68.24797987937927,
+                15.913596749305725,
+                14.516602456569672,
+                0,
+                0
+            ],
+            group: "apexcharts-axis-0"
+        },
+        {
+            name: "https://www.readerswarehouse.co.za",
+            data: [
+                0,
+                0,
+                16.29459708929062,
+                23.511777818202972,
+                16.00102037191391
+            ],
+            group: "apexcharts-axis-0"
+        }
+      ]
+    },
     industryClassification: {
       unclassifiedUrls: ['https://www.example.com'],
       industryPercentages: {
@@ -109,6 +142,42 @@ describe('SummaryReport Page', () => {
     parkedUrls: ['https://www.example2.com'],
     scrapableUrls: 2,
     avgTime: 100,
+    metaRadar: {
+      categories: [
+        "Finance and Banking",
+        "Utilities",
+        "Marine Resources",
+        "Hospitality",
+        "Marine and Shipping",
+        "Telecommunications"
+      ],
+      series: [
+        {
+            name: "https://www.nedbank.co.za",
+            data: [
+                68.75752806663513,
+                18.95316243171692,
+                18.465912342071533,
+                0,
+                0,
+                0
+            ],
+            group: "apexcharts-axis-0"
+        },
+        {
+            name: "https://www.readerswarehouse.co.za",
+            data: [
+                0,
+                0,
+                0,
+                16.464106738567352,
+                15.834927558898926,
+                15.723402798175812
+            ],
+            group: "apexcharts-axis-0"
+        }
+      ]
+    }
   };
 
   const mockUser = {
@@ -139,8 +208,15 @@ describe('SummaryReport Page', () => {
     expect(screen.getByText('100 sec')).toBeInTheDocument(); // Average Time
   });
 
+  it("display radar graphs on bigger screens", () => {
+    render(<SummaryReport />);
+
+    expect(screen.queryByTestId('metaRadar')).toBeInTheDocument();
+    expect(screen.queryByTestId('domainRadar')).toBeInTheDocument();
+  });
+
   it("don't display radar graphs on mobile phone", () => {
-    global.innerWidth = 250;
+    global.innerWidth = 150;
     global.dispatchEvent(new Event('resize'));
 
     render(<SummaryReport />);
@@ -148,8 +224,14 @@ describe('SummaryReport Page', () => {
     expect(screen.getByText('Sorry, the metadata radar graph is not available on mobile devices')).toBeInTheDocument();
     expect(screen.getByText('Sorry, the domain radar graph is not available on mobile devices')).toBeInTheDocument();
 
-    expect(screen.queryByTestId('metaRadar')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('domainRadar')).not.toBeInTheDocument();
+    const metaRadar = screen.queryByTestId('metaRadar');
+    const domainRadar = screen.queryByTestId('domainRadar');
+
+    expect(metaRadar).toBeInTheDocument();
+    expect(domainRadar).toBeInTheDocument();
+
+    expect(metaRadar).toHaveClass('hidden');
+    expect(domainRadar).toHaveClass('hidden');
   });
 
   it('should call jsPDF and download the PDF when download button is clicked', async () => {

--- a/wee/frontend/src/app/(pages)/summaryreport/page.tsx
+++ b/wee/frontend/src/app/(pages)/summaryreport/page.tsx
@@ -420,11 +420,11 @@ export default function SummaryReport() {
                     <span className='block sm:hidden'>
                         Sorry, the metadata radar graph is not available on mobile devices
                     </span>
-                    <span className='hidden sm:block'>
-                        {metaRadar && metaRadar.categories.length > 0 && metaRadar.series.length > 0 ? (
-                            <RadarChart data-testid="metaRadar" radarCategories={metaRadar.categories} radarSeries={metaRadar.series} />
-                        ) : (<></>)}
+                    {metaRadar && metaRadar.categories.length > 0 && metaRadar.series.length > 0 ? (
+                    <span data-testid="metaRadar" className='hidden sm:block'>
+                        <RadarChart radarCategories={metaRadar.categories} radarSeries={metaRadar.series} />
                     </span>
+                    ) : (<></>)}
                 </div>
                 <div className='bg-zinc-200 dark:bg-zinc-700 p-4 rounded-xl md:col-span-1'>
                     <h3 className="font-poppins-semibold text-lg text-jungleGreen-700 dark:text-jungleGreen-100 mb-4 text-center">
@@ -433,11 +433,11 @@ export default function SummaryReport() {
                     <span className='block sm:hidden'>
                         Sorry, the domain radar graph is not available on mobile devices
                     </span>
-                    <span className='hidden sm:block'>
-                        {domainRadar && domainRadar.categories.length > 0 && domainRadar.series.length > 0 ? (
-                            <RadarChart data-testid="domainRadar" radarCategories={domainRadar.categories} radarSeries={domainRadar.series} />
-                        ) : (<></>)}
+                    {domainRadar && domainRadar.categories.length > 0 && domainRadar.series.length > 0 ? (
+                    <span data-testid="domainRadar"  className='hidden sm:block'>
+                        <RadarChart radarCategories={domainRadar.categories} radarSeries={domainRadar.series} />
                     </span>
+                    ) : (<></>)}
                 </div>
             </div>
 

--- a/wee/frontend/src/app/(pages)/summaryreport/page.tsx
+++ b/wee/frontend/src/app/(pages)/summaryreport/page.tsx
@@ -422,7 +422,7 @@ export default function SummaryReport() {
                     </span>
                     <span className='hidden sm:block'>
                         {metaRadar && metaRadar.categories.length > 0 && metaRadar.series.length > 0 ? (
-                            <RadarChart radarCategories={metaRadar.categories} radarSeries={metaRadar.series} />
+                            <RadarChart data-testid="metaRadar" radarCategories={metaRadar.categories} radarSeries={metaRadar.series} />
                         ) : (<></>)}
                     </span>
                 </div>
@@ -435,7 +435,7 @@ export default function SummaryReport() {
                     </span>
                     <span className='hidden sm:block'>
                         {domainRadar && domainRadar.categories.length > 0 && domainRadar.series.length > 0 ? (
-                            <RadarChart radarCategories={domainRadar.categories} radarSeries={domainRadar.series} />
+                            <RadarChart data-testid="domainRadar" radarCategories={domainRadar.categories} radarSeries={domainRadar.series} />
                         ) : (<></>)}
                     </span>
                 </div>

--- a/wee/frontend/src/app/(pages)/summaryreport/page.tsx
+++ b/wee/frontend/src/app/(pages)/summaryreport/page.tsx
@@ -417,17 +417,27 @@ export default function SummaryReport() {
                     <h3 className="font-poppins-semibold text-lg text-jungleGreen-700 dark:text-jungleGreen-100 mb-4 text-center">
                         Metadata
                     </h3>
-                    {metaRadar && metaRadar.categories.length > 0 && metaRadar.series.length > 0 ? (
-                        <RadarChart radarCategories={metaRadar.categories} radarSeries={metaRadar.series} />
-                    ) : (<></>)}
+                    <span className='block sm:hidden'>
+                        Sorry, the metadata radar graph is not available on mobile devices
+                    </span>
+                    <span className='hidden sm:block'>
+                        {metaRadar && metaRadar.categories.length > 0 && metaRadar.series.length > 0 ? (
+                            <RadarChart radarCategories={metaRadar.categories} radarSeries={metaRadar.series} />
+                        ) : (<></>)}
+                    </span>
                 </div>
                 <div className='bg-zinc-200 dark:bg-zinc-700 p-4 rounded-xl md:col-span-1'>
                     <h3 className="font-poppins-semibold text-lg text-jungleGreen-700 dark:text-jungleGreen-100 mb-4 text-center">
                         Domain
                     </h3>
-                    {domainRadar && domainRadar.categories.length > 0 && domainRadar.series.length > 0 ? (
-                        <RadarChart radarCategories={domainRadar.categories} radarSeries={domainRadar.series} />
-                    ) : (<></>)}
+                    <span className='block sm:hidden'>
+                        Sorry, the domain radar graph is not available on mobile devices
+                    </span>
+                    <span className='hidden sm:block'>
+                        {domainRadar && domainRadar.categories.length > 0 && domainRadar.series.length > 0 ? (
+                            <RadarChart radarCategories={domainRadar.categories} radarSeries={domainRadar.series} />
+                        ) : (<></>)}
+                    </span>
                 </div>
             </div>
 


### PR DESCRIPTION
## Description
Don't display the radar graphs on a mobile phone like an iphone SE

## Changes Made
Don't display the radar graphs on a mobile phone like an iphone SE

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/b746845e-47e6-494c-9c47-cb60e25432e1)

![image](https://github.com/user-attachments/assets/d98d3a28-f2ed-4964-b238-2c077e479394)

## Related Issues
#339 

## Checklist
- [x] I have tested this code locally
- [x] I have reviewed the code for readability and maintainability
- [ ] I have added appropriate documentation or updated existing documentation
- [ ] I have ensured that my changes follow the project's coding conventions
- [ ] I have performed additional steps, if required [e.g., database migrations, configuration changes, etc.]

## Additional Notes
[Include any additional notes or context relevant to the pull request]
