### PR TITLE
Feature/test tech seo integration

### DIFF
--- a/wee/frontend/cypress/README.md
+++ b/wee/frontend/cypress/README.md
@@ -177,3 +177,23 @@ Use cy.debug() to print debug information to the console.
 ```javascript
 cy.get('input[name="username"]').type('user1').debug();
 ```
+
+## Frontend Cypress Folder Structure
+
+```bash
+├── fixtures # mock data
+│   ├── pub-sub # contains mock data for pub-sub setup
+│   └── etc # contains mock data for previous api versions
+├── integration # contains the cypress test files
+│   ├── results.cy.ts # 
+│   └── etc # folder contains other files of same format and purpose
+├── plugins 
+│   ├── codecov support
+│   └── etc # folder contains other files of same format and purpose
+├── support
+│   ├── commands.ts # file containing custom commands used by all cypress files
+│   └── etc # contains default config files for cypress
+└── templates # test templates - one for each page in **frontend/src/** folder
+    ├── results.ts # the full test template for results.tsx page
+    └── etc # folder contains other files of same format and purpose
+```

--- a/wee/frontend/cypress/integration/comparison.cy.ts
+++ b/wee/frontend/cypress/integration/comparison.cy.ts
@@ -272,7 +272,7 @@ describe('comparison page', () => {
     cy.get('[data-testid="btn-comparison-summary"]').should('exist');
     cy.get('[data-testid="btn-comparison-summary"]').click();
 
-    // We are now on the Comparison Page
+    // On the Comparison Page
 
     //Select first website to compare
     cy.get('[data-testid="website1-select"]').should('exist');
@@ -291,8 +291,73 @@ describe('comparison page', () => {
     cy.get('[data-testid="website2-option-1"]').click();
 
     //Check all corresponding website
+
+
+    
+    //Section : Light House Analysis
+
+    //Website 1
+    cy.get('[data-testid="website1-lighthouse-performance"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0%');
+
+    cy.get('[data-testid="website1-lighthouse-accessibility"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0%');
+
+    cy.get('[data-testid="website1-lighthouse-bestpractices"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0%');
+
+    //Website 2
+    cy.get('[data-testid="website2-lighthouse-performance"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0%');
+
+    cy.get('[data-testid="website2-lighthouse-accessibility"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0%');
+
+    cy.get('[data-testid="website2-lighthouse-bestpractices"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0%');
+
+    
+    // Section : Mobile Friendly
+    
+    cy.get('[data-testid="website1-mobilefriendly"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'Yes');
+
+
+    cy.get('[data-testid="website2-mobilefriendly"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'Yes');
+
+    
+    
+    // Section : Site Speed
+    
+    cy.get('[data-testid="website1-sitespeed"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0');
+
+
+    cy.get('[data-testid="website2-sitespeed"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0');
+
+
   });
-
-
 
 });

--- a/wee/frontend/cypress/integration/results.cy.ts
+++ b/wee/frontend/cypress/integration/results.cy.ts
@@ -1,56 +1,56 @@
 describe('results', () => {
-  // it('general layout intact', () => {
-  //   cy.testLayout('/results');
-  // });
+  it('general layout intact', () => {
+    cy.testLayout('/results');
+  });
 
-  // it('all page content should load', () => {
-  //   cy.visit('/results?');
+  it('all page content should load', () => {
+    cy.visit('/results?');
 
-  //   //Testing Export / Save Button
-  //   cy.get('[data-testid="btn-export-save-report"]').should('exist');
-  //   cy.get('[data-testid="btn-export-save-report"]').click();
-  //   cy.get('[data-testid="btn-export-save-report"]').should('exist');
+    //Testing Export / Save Button
+    cy.get('[data-testid="btn-export-save-report"]').should('exist');
+    cy.get('[data-testid="btn-export-save-report"]').click();
+    cy.get('[data-testid="btn-export-save-report"]').should('exist');
 
 
-  //   //Page Tab : General Overview
-  //   cy.log('Testing General overview tab');
+    //Page Tab : General Overview
+    cy.log('Testing General overview tab');
 
-  //   cy.contains(/overview/i).should('exist');
-  //   cy.contains(/parked/i).should('exist');
-  //   cy.contains(/seo/i).should('exist');
-  //   cy.contains(/contact details/i).should('exist');
+    cy.contains(/overview/i).should('exist');
+    cy.contains(/parked/i).should('exist');
+    cy.contains(/seo/i).should('exist');
+    cy.contains(/contact details/i).should('exist');
 
-  //   cy.log('Testing tabs and buttons exist');
-  //   cy.get('[data-testid="tab-seo"]').should('exist');
-  //   cy.get('[data-testid="tab-seo"]').click();
-  //   cy.contains(/media/i).should('exist');
-  //   cy.contains(/seo/i).should('exist');
-  //   cy.contains(/export/i).should('exist');
+    cy.log('Testing tabs and buttons exist');
+    cy.get('[data-testid="tab-seo"]').should('exist');
+    cy.get('[data-testid="tab-seo"]').click();
+    cy.contains(/media/i).should('exist');
+    cy.contains(/seo/i).should('exist');
+    cy.contains(/export/i).should('exist');
 
-  //   // Page Tab : Media
-  //   cy.log('Testing Media Tab');
+    // Page Tab : Media
+    cy.log('Testing Media Tab');
 
-  //   cy.get('[data-testid="tab-media"]').click();
-  //   cy.contains(/screenshot/i).should('exist');
-  //   cy.contains(/screenshot available./i).should('exist');
-  //   cy.contains(/images/i).should('exist');
-  //   cy.contains(/No images available/i).should('exist');
+    cy.get('[data-testid="tab-media"]').click();
+    cy.contains(/screenshot/i).should('exist');
+    cy.contains(/screenshot available./i).should('exist');
+    cy.contains(/images/i).should('exist');
+    cy.contains(/No images available/i).should('exist');
 
-  //   // Page Tab : SEO Analysis
-  //   cy.log('Testing SEO Analysis');
+    // Page Tab : SEO Analysis
+    cy.log('Testing SEO Analysis');
 
-  //   cy.get('[data-testid="tab-seo"]').click();
-  //   cy.contains(/images/i).should('exist');
-  //   cy.contains(/internal linking/i).should('exist');
-  //   cy.contains(/headings/i).should('exist');
-  //   cy.contains(/meta/i).should('exist');
-  //   cy.contains(/title tags/i).should('exist');
-  //   cy.contains(/unique content/i).should('exist');
+    cy.get('[data-testid="tab-seo"]').click();
+    cy.contains(/images/i).should('exist');
+    cy.contains(/internal linking/i).should('exist');
+    cy.contains(/headings/i).should('exist');
+    cy.contains(/meta/i).should('exist');
+    cy.contains(/title tags/i).should('exist');
+    cy.contains(/unique content/i).should('exist');
 
-  //   // Page Tab : Sentiment Analysis
-  //   cy.log('Testing Sentiment Analysis');
+    // Page Tab : Sentiment Analysis
+    cy.log('Testing Sentiment Analysis');
 
-  // });
+  });
 
   it('scrape 2 urls - github, steers', () => {
     cy.visit('/');

--- a/wee/frontend/cypress/integration/results.cy.ts
+++ b/wee/frontend/cypress/integration/results.cy.ts
@@ -1,58 +1,58 @@
 describe('results', () => {
-  it('general layout intact', () => {
-    cy.testLayout('/results');
-  });
+  // it('general layout intact', () => {
+  //   cy.testLayout('/results');
+  // });
 
-  it('all page content should load', () => {
-    cy.visit('/results?');
+  // it('all page content should load', () => {
+  //   cy.visit('/results?');
 
-    //Testing Export / Save Button
-    cy.get('[data-testid="btn-export-save-report"]').should('exist');
-    cy.get('[data-testid="btn-export-save-report"]').click();
-    cy.get('[data-testid="btn-export-save-report"]').should('exist');
+  //   //Testing Export / Save Button
+  //   cy.get('[data-testid="btn-export-save-report"]').should('exist');
+  //   cy.get('[data-testid="btn-export-save-report"]').click();
+  //   cy.get('[data-testid="btn-export-save-report"]').should('exist');
 
 
-    //Page Tab : General Overview
-    cy.log('Testing General overview tab');
+  //   //Page Tab : General Overview
+  //   cy.log('Testing General overview tab');
 
-    cy.contains(/overview/i).should('exist');
-    cy.contains(/parked/i).should('exist');
-    cy.contains(/seo/i).should('exist');
-    cy.contains(/contact details/i).should('exist');
+  //   cy.contains(/overview/i).should('exist');
+  //   cy.contains(/parked/i).should('exist');
+  //   cy.contains(/seo/i).should('exist');
+  //   cy.contains(/contact details/i).should('exist');
 
-    cy.log('Testing tabs and buttons exist');
-    cy.get('[data-testid="tab-seo"]').should('exist');
-    cy.get('[data-testid="tab-seo"]').click();
-    cy.contains(/media/i).should('exist');
-    cy.contains(/seo/i).should('exist');
-    cy.contains(/export/i).should('exist');
+  //   cy.log('Testing tabs and buttons exist');
+  //   cy.get('[data-testid="tab-seo"]').should('exist');
+  //   cy.get('[data-testid="tab-seo"]').click();
+  //   cy.contains(/media/i).should('exist');
+  //   cy.contains(/seo/i).should('exist');
+  //   cy.contains(/export/i).should('exist');
 
-    // Page Tab : Media
-    cy.log('Testing Media Tab');
+  //   // Page Tab : Media
+  //   cy.log('Testing Media Tab');
 
-    cy.get('[data-testid="tab-media"]').click();
-    cy.contains(/screenshot/i).should('exist');
-    cy.contains(/screenshot available./i).should('exist');
-    cy.contains(/images/i).should('exist');
-    cy.contains(/No images available/i).should('exist');
+  //   cy.get('[data-testid="tab-media"]').click();
+  //   cy.contains(/screenshot/i).should('exist');
+  //   cy.contains(/screenshot available./i).should('exist');
+  //   cy.contains(/images/i).should('exist');
+  //   cy.contains(/No images available/i).should('exist');
 
-    // Page Tab : SEO Analysis
-    cy.log('Testing SEO Analysis');
+  //   // Page Tab : SEO Analysis
+  //   cy.log('Testing SEO Analysis');
 
-    cy.get('[data-testid="tab-seo"]').click();
-    cy.contains(/images/i).should('exist');
-    cy.contains(/internal linking/i).should('exist');
-    cy.contains(/headings/i).should('exist');
-    cy.contains(/meta/i).should('exist');
-    cy.contains(/title tags/i).should('exist');
-    cy.contains(/unique content/i).should('exist');
+  //   cy.get('[data-testid="tab-seo"]').click();
+  //   cy.contains(/images/i).should('exist');
+  //   cy.contains(/internal linking/i).should('exist');
+  //   cy.contains(/headings/i).should('exist');
+  //   cy.contains(/meta/i).should('exist');
+  //   cy.contains(/title tags/i).should('exist');
+  //   cy.contains(/unique content/i).should('exist');
 
-    // Page Tab : Sentiment Analysis
-    cy.log('Testing Sentiment Analysis');
+  //   // Page Tab : Sentiment Analysis
+  //   cy.log('Testing Sentiment Analysis');
 
-  });
+  // });
 
-  it('results of 2 urls - github, steers', () => {
+  it('scrape 2 urls - github, steers', () => {
     cy.visit('/');
     cy.get('[data-testid="scraping-textarea-home"]').type(
       'https://mock.test.github.com,https://mock.test.steers.co.za'
@@ -355,7 +355,113 @@ describe('results', () => {
     //     'contain.text','array'
     //   )
 
+    // Test Technical Analysis
+
+    cy.log('Testing Sentiment Analysis');
+    
+    cy.get('[data-testid="canonicalTagPresent"]')
+      .should('exist')
+      .should('be.visible')
+      .should('contain.text', 'Yes');
+
+    cy.get('[data-testid="canonicalTag"]')
+      .should('exist')
+      .should('be.visible')
+      .should('contain.text', 'https://steers.co.za');
+
+    // cy.get('[data-testid="canonical_recommendations"]')
+    //   .should('exist')
+    //   .should('be.visible')
+    //   .should('contain.text', '');
+
+    cy.get('[data-testid="siteSpeed"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0');
+
+    // cy.get('[data-testid="sitespeed_recommendations"]')
+    // .should('exist')
+    // .should('be.visible')
+    // .should('contain.text', '0');
+
+    cy.get('[data-testid="isSitemapvalid"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'Yes')
+    
+    // cy.get('[data-testid="xml_recommendation"]')
+    // .should('exist')
+    // .should('be.visible')
+    // .should('contain.text', 'Yes')
+
+    cy.get('[data-testid="mobile_friendliness"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'Yes')
+    
+    
+    // cy.get('[data-testid="mobile_recommendations"]')
+    // .should('exist')
+    // .should('be.visible')
+    // .should('contain.text', 'Yes')
+    
+    
+    cy.get('[data-testid="indexibilityAnalysis"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'Yes')
+    
+    
+    // cy.get('[data-testid="indexable_recommendation"]')
+    // .should('exist')
+    // .should('be.visible')
+    // .should('contain.text', 'Yes')
+    
+    
+    cy.get('[data-testid="structuredData"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0')
+    
+    
+    cy.get('[data-testid="structured_recommendations"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'No structured data found. Add structured data to improve SEO.')
+    
+    
+    // Testing Lighthouse analysis
+
+    // cy.get('[data-testid="lighthouse-performance"]')
+    // .should('exist')
+    // .should('be.visible')
+    // .should('contain.text', 'No structured data found. Add stuctured data to improve SEO.')
+
+      
+    // cy.get('[data-testid="lighthouse-performance"]')
+    // .should('exist')
+    // .should('be.visible')
+    // .should('contain.text', 'No structured data found. Add stuctured data to improve SEO.')
+
+      
+    // cy.get('[data-testid="lighthouse-bestpractices"]')
+    // .should('exist')
+    // .should('be.visible')
+    // .should('contain.text', 'No structured data found. Add stuctured data to improve SEO.')
+    
+    // cy.get('[data-testid="lighthouse_recommendation_"]')
+    // .should('exist')
+    // .should('be.visible')
+    // .should('contain.text', 'No structured data found. Add stuctured data to improve SEO.')
+
+      
+
+    
     //  Tab : Sentiment Analysis
     cy.log('Testing Sentiment Analysis');
+
+
   });
+
+
 });

--- a/wee/frontend/cypress/support/screenshots.ts
+++ b/wee/frontend/cypress/support/screenshots.ts
@@ -5,19 +5,19 @@ describe('scraping functionality', () => {
       cy.visit('/');
   
       // Note : Dont test the modal screenshot before testing
-      cy.screenshot('homepage');
-/*       cy.compareSnapshot({
-        name: 'homepage',
-        testThreshold: 0.2
-      }) */
-   /*    
+      // cy.screenshot('homepage');
+      //  cy.compareSnapshot({
+      //   name: 'homepage',
+      //   testThreshold: 0.2
+      // }) 
+
       cy.get('[data-testid="header"]').screenshot('header-logged-out');
       cy.get('[data-testid="footer"]').screenshot('footer');
   
       cy.get('[data-testid="help-button"]').click();
       cy.get('[data-testid="help-button"]').screenshot('btn-help');
       cy.get('[data-testid="help-modal"]').screenshot('help-modal');
-      cy.get('[data-testid="help-button"]').click(); */
+      cy.get('[data-testid="help-button"]').click();
     });
 
 });

--- a/wee/frontend/cypress/templates/SHORTCUTS.md
+++ b/wee/frontend/cypress/templates/SHORTCUTS.md
@@ -1,0 +1,6 @@
+```typescript
+    cy.get('[data-testid="canonical_recommendations"]')
+      .should('exist')
+      .should('be.visible')
+      .should('contain.text', '');
+```

--- a/wee/frontend/cypress/templates/comparison.ts
+++ b/wee/frontend/cypress/templates/comparison.ts
@@ -1,0 +1,84 @@
+ // On the Comparison Page
+
+    //Select first website to compare
+    cy.get('[data-testid="website1-select"]').should('exist');
+    cy.get('[data-testid="website1-select"]').click();
+
+    cy.get('[data-testid="website1-option-0"]').should('exist');
+    cy.get('[data-testid="website1-option-1"]').should('exist');
+    cy.get('[data-testid="website1-option-1"]').click();
+
+    //Select second website to compare
+    cy.get('[data-testid="website2-select"]').should('exist');
+    cy.get('[data-testid="website2-select"]').click();
+
+    cy.get('[data-testid="website2-option-0"]').should('exist');
+    cy.get('[data-testid="website2-option-1"]').should('exist');
+    cy.get('[data-testid="website2-option-1"]').click();
+
+    //Check all corresponding website
+
+
+    
+    //Section : Light House Analysis
+
+    //Website 1
+    cy.get('[data-testid="website1-lighthouse-performance"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0%');
+
+    cy.get('[data-testid="website1-lighthouse-accessibility"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0%');
+
+    cy.get('[data-testid="website1-lighthouse-bestpractices"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0%');
+
+    //Website 2
+    cy.get('[data-testid="website2-lighthouse-performance"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0%');
+
+    cy.get('[data-testid="website2-lighthouse-accessibility"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0%');
+
+    cy.get('[data-testid="website2-lighthouse-bestpractices"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0%');
+
+    
+    // Section : Mobile Friendly
+    
+    cy.get('[data-testid="website1-mobilefriendly"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'Yes');
+
+
+    cy.get('[data-testid="website2-mobilefriendly"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'Yes');
+
+    
+    
+    // Section : Site Speed
+    
+    cy.get('[data-testid="website1-sitespeed"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0');
+
+
+    cy.get('[data-testid="website2-sitespeed"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0');

--- a/wee/frontend/cypress/templates/results.ts
+++ b/wee/frontend/cypress/templates/results.ts
@@ -1,0 +1,306 @@
+
+    //==========================================
+    // Checking the results page content : Steers
+    //==========================================
+
+    cy.get('[data-testid="btnView1"]').should('exist').click();
+
+    cy.url().should('include', 'results');
+
+    //  Tab : General Overview
+    cy.log('Testing General overview tab');
+
+    cy.get('[data-testid="tab-general"]').should('exist');
+    cy.get('[data-testid="tab-general"]').click();
+
+    //Tab Section : Header, Title, Logo
+    cy.get('[data-testid="div-summary"]').should('exist').should('be.visible');
+
+    cy.get('[data-testid="p-title"]')
+      .should('exist')
+      .should('be.visible')
+      .should('contain.text', 'Burgers and Flame Grills | Steers South Africa');
+
+    cy.get('[data-testid="img-logo"]')
+      .should('exist')
+      .should('have.attr', 'src');
+
+    cy.get('[data-testid="p-summary"]')
+      .should('exist')
+      .should('be.visible')
+      .should(
+        'contain.text',
+        'Nothing slaps more than 100% Flame-Grilled flavour. Steers South Africa is the takeaway restaurant of choice for burgers, chicken, ribs and hand-cut chips.'
+      );
+    // Tab Section : Summary Info
+
+    //  Tab : Media
+    cy.log('Testing Media Tab');
+    cy.get('[data-testid="tab-media"]').click();
+
+    cy.get('[data-testid="div-homepagescreenshot"]')
+      .should('exist')
+      .should('be.visible');
+
+    cy.get('[data-testid="pagination-images"]')
+      .should('exist')
+      .should('be.visible');
+
+    // Check the select dropdown for "Images Per Page"
+    cy.get('[data-testid="pagination-images"] select')
+      .should('be.visible')
+      .find('option')
+      .should('have.length', 6) // There are 6 options
+      .then(($options) => {
+        const expectedValues = ['4', '8', '16', '24', '36', '48'];
+        $options.each((index, option) => {
+          expect(option.value).to.equal(expectedValues[index]);
+        });
+      });
+
+    // Check the images in the cards
+    cy.get('[id="unique-results-image-container"]')
+      .find('[id="unique-results-image"]')
+      .should('have.length.greaterThan', 0); // Ensure there is at least one image
+
+    cy.get('[id="unique-results-image-container"]')
+      .find('img')
+      .should('have.attr', 'alt', 'Image')
+      .and('have.attr', 'src'); // Ensure images have src attribute
+
+    //  Tab : SEO Analysis
+    cy.log('Testing SEO Analysis');
+
+    cy.get('[data-testid="tab-seo"]').click();
+
+    //Check Titles
+    cy.contains(/images/i).should('exist');
+    cy.contains(/internal linking/i).should('exist');
+    cy.contains(/headings/i).should('exist');
+    cy.contains(/meta/i).should('exist');
+    cy.contains(/title tags/i).should('exist');
+    cy.contains(/unique content/i).should('exist');
+
+    cy.get('[data-testid="div-images-total"]')
+      .should('exist')
+      .should('be.visible')
+      .should('contain.text', '26');
+
+    cy.get('[data-testid="div-images-missing-alt"]')
+      .should('exist')
+      .should('be.visible')
+      .should('contain.text', '2');
+
+    cy.get('[data-testid="nonOptimisedImages"]')
+      .should('exist')
+      .should('be.visible')
+      .should('contain.text', '0');
+
+    cy.get('[data-testid="scroll-format-urls"]')
+    .should('exist')
+    .should('be.visible')
+    .should(
+        'contain.text','110'      )
+
+    cy.get('[data-testid="div-format-urls"]')
+    .should('exist')
+    .should('be.visible')
+    .should(
+        'contain.text','47'      )
+
+    cy.get('[data-testid="div-other-urls"]')
+    .should('exist')
+    .should('be.visible')
+    .should(
+        'contain.text','abc'
+      )
+
+    cy.get('[data-testid="div-links-total"]')
+    .should('exist')
+    .should('be.visible')
+    .should(
+        'contain.text','abc'
+      )
+
+    //Heading Analysis
+    cy.get('[data-testid="headingscount"]')
+      .should('exist')
+      .should('be.visible')
+      .should('contain.text', '1');
+
+    cy.get('[data-testid="popup-headings"]')
+      .should('exist')
+      .should('be.visible')
+      .should('contain.text', 'Welcome to Steers®, the home of Flame-Grilled');
+
+    // MetaDescription Analysis
+    cy.get('[data-testid="p-metadescription-tag"]')
+    .should('exist')
+    .should('be.visible')
+    .should(
+        'contain.text','array'
+      )
+
+    cy.get('[data-testid="p-metadescription-length"]')
+    .should('exist')
+    .should('be.visible')
+    .should(
+        'contain.text','array'
+      )
+
+    // EO MetaDescription Analysis
+    cy.get('[data-testid="p-metadescription"]')
+    .should('exist')
+    .should('be.visible')
+    .should(
+        'contain.text','array'
+      )
+
+    cy.get('[data-testid="p-titletag-description"]')
+    .should('exist')
+    .should('be.visible')
+    .should(
+        'contain.text','array'
+      )
+
+    cy.get('[data-testid="p-titletag-length"]')
+    .should('exist')
+    .should('be.visible')
+    .should(
+        'contain.text','array'
+      )
+
+    //Unique Content
+    cy.get('[data-testid="p-titletag-length"]')
+    .should('exist')
+    .should('be.visible')
+    .should(
+        'contain.text','array'
+      )
+    cy.get('[data-testid="div-uniq-textlength"]')
+      .should('exist')
+      .should('be.visible')
+      .should('contain.text', '303');
+    cy.get('[data-testid="div-uniq-percentage"]')
+      .should('exist')
+      .should('be.visible')
+      .should('contain.text', '52.81%');
+
+    cy.get('[data-testid="div-uniq-rep-words"]')
+      .should('exist')
+      .should('be.visible')
+      .should('contain.text', 'king: 5burger: 5only: 4');
+
+   // Sentiment Analysis
+    cy.get('[data-testid="div-sentiment-analysis"]')
+    .should('exist')
+    .should('be.visible')
+    .should(
+        'contain.text','array'
+      )
+
+    // Test Technical Analysis
+
+    cy.log('Testing Sentiment Analysis');
+    
+    cy.get('[data-testid="canonicalTagPresent"]')
+      .should('exist')
+      .should('be.visible')
+      .should('contain.text', 'Yes');
+
+    cy.get('[data-testid="canonicalTag"]')
+      .should('exist')
+      .should('be.visible')
+      .should('contain.text', 'https://steers.co.za');
+
+    cy.get('[data-testid="canonical_recommendations"]')
+      .should('exist')
+      .should('be.visible')
+      .should('contain.text', '');
+
+    cy.get('[data-testid="siteSpeed"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0');
+
+    cy.get('[data-testid="sitespeed_recommendations"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0');
+
+    cy.get('[data-testid="isSitemapvalid"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'Yes')
+    
+    cy.get('[data-testid="xml_recommendation"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'Yes')
+
+    cy.get('[data-testid="mobile_friendliness"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'Yes')
+    
+    
+    cy.get('[data-testid="mobile_recommendations"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'Yes')
+    
+    
+    cy.get('[data-testid="indexibilityAnalysis"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'Yes')
+    
+    
+    cy.get('[data-testid="indexable_recommendation"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'Yes')
+    
+    
+    cy.get('[data-testid="structuredData"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', '0')
+    
+    
+    cy.get('[data-testid="structured_recommendations"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'No structured data found. Add structured data to improve SEO.')
+    
+    
+    //Testing Lighthouse analysis
+
+    cy.get('[data-testid="lighthouse-performance"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'No structured data found. Add stuctured data to improve SEO.')
+
+      
+    cy.get('[data-testid="lighthouse-performance"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'No structured data found. Add stuctured data to improve SEO.')
+
+      
+    cy.get('[data-testid="lighthouse-bestpractices"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'No structured data found. Add stuctured data to improve SEO.')
+    
+    cy.get('[data-testid="lighthouse_recommendation_"]')
+    .should('exist')
+    .should('be.visible')
+    .should('contain.text', 'No structured data found. Add stuctured data to improve SEO.')
+
+      
+
+    
+    //  Tab : Sentiment Analysis
+    cy.log('Testing Sentiment Analysis');
+


### PR DESCRIPTION
## Description
Add integration cypress tests to technical SEO analysis

## Changes Made
- add testing technical seo analysis on results and comparison pages
- add templates folder to cypress frontend 

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/e16ca69a-7b55-42f1-a21c-8a8d53f2f064)
![image](https://github.com/user-attachments/assets/6a0be93d-e512-4055-b0bd-2de0211963b6)


## Related Issues
#348

## Checklist
- [x] I have tested this code locally
- [x] I have reviewed the code for readability and maintainability
- [x] I have added appropriate documentation or updated existing documentation
- [x] I have ensured that my changes follow the project's coding conventions
- [x] I have performed additional steps, if required [e.g., database migrations, configuration changes, etc.]

## Additional Notes
- The purpose of the cypress/templates folder is for code written to be used in the e2e tests later on