### PR TITLE
Hotfix/sanitize inputs

### DIFF
--- a/wee/frontend/specs/services/sanitizeInputText.spec.tsx
+++ b/wee/frontend/specs/services/sanitizeInputText.spec.tsx
@@ -1,0 +1,32 @@
+import { sanitizeInputText } from "../../src/Utils/sanitizeInputText";
+
+describe('sanitizeInputText', () => {
+    it('should escape HTML special characters', () => {
+        const input = '<script>alert("XSS");</script>';
+        const expectedOutput = '&lt;script&gt;alert&#40;&quot;XSS&quot;&#41;;&lt;&#x2F;script&gt;';
+        expect(sanitizeInputText(input)).toBe(expectedOutput);
+    });
+
+    it('should escape ampersands', () => {
+        const input = 'Fish & Chips';
+        const expectedOutput = 'Fish &amp; Chips';
+        expect(sanitizeInputText(input)).toBe(expectedOutput);
+    });
+
+    it('should escape single quotes', () => {
+        const input = "It's a test";
+        const expectedOutput = "It&#039;s a test";
+        expect(sanitizeInputText(input)).toBe(expectedOutput);
+    });
+
+    it('should escape multiple special characters', () => {
+        const input = 'Use <tag> or "quote" & other (characters) /';
+        const expectedOutput = 'Use &lt;tag&gt; or &quot;quote&quot; &amp; other &#40;characters&#41; &#x2F;';
+        expect(sanitizeInputText(input)).toBe(expectedOutput);
+    });
+
+    it('should return the same string if there are no special characters', () => {
+        const input = 'Hello World!';
+        expect(sanitizeInputText(input)).toBe(input);
+    });
+});

--- a/wee/frontend/specs/unit/Results.spec.tsx
+++ b/wee/frontend/specs/unit/Results.spec.tsx
@@ -2118,6 +2118,43 @@ describe('Results Component', () => {
         expect(confirmButton).toBeDisabled();
     });
 
+    it('should enter an error state if invalid name is entered', async () => {
+        render(<Results />);
+
+        // Ensure the component has rendered and the dropdown button is available
+        const dropdownButton = screen.getByRole('button', { name: /export\/save/i });
+        expect(dropdownButton).toBeInTheDocument();
+
+        // Click the dropdown button to open the menu
+        fireEvent.click(dropdownButton);
+
+        // Wait for the save button to appear
+        const saveButton = await screen.findByTestId('save-report-button');
+        expect(saveButton).toBeInTheDocument();
+
+        // Click the save button
+        fireEvent.click(saveButton);
+
+        // Wait for the modal to appear
+        const modal = await screen.findByTestId('save-report-modal');
+        expect(modal).toBeInTheDocument();
+
+        // Enter a report name
+        const reportNameInput = screen.getByLabelText(/Report Name/i);
+        expect(reportNameInput).toBeInTheDocument();
+        fireEvent.change(reportNameInput, { target: { value: 'Here :)' } });
+
+        fireEvent.click(screen.getByTestId('submit-report-name'));
+
+        // Check if the input has entered an invalid state
+        expect(reportNameInput).toHaveAttribute('aria-invalid', 'true');
+    
+        // Check if the correct error message is displayed
+        const errorMessage = screen.getByText('Report name is invalid. Only letters, numbers, !?& are allowed.');
+        expect(errorMessage).toBeInTheDocument();
+    });
+
+
     it('should call the saveReport function when the save button is clicked', async () => {
         render(<Results />);
 

--- a/wee/frontend/specs/unit/SummaryReport.spec.tsx
+++ b/wee/frontend/specs/unit/SummaryReport.spec.tsx
@@ -425,6 +425,42 @@ describe('SummaryReport Page', () => {
     expect(inputWithError).toBeInTheDocument();
   });
 
+  it('should enter an error state if invalid name is entered', async () => {
+    render(<SummaryReport />);
+
+    // Ensure the component has rendered and the dropdown button is available
+    const dropdownButton = screen.getByRole('button', { name: /export\/save/i });
+    expect(dropdownButton).toBeInTheDocument();
+
+    // Click the dropdown button to open the menu
+    fireEvent.click(dropdownButton);
+
+    // Wait for the save button to appear
+    const saveButton = await screen.findByTestId('save-report-button');
+    expect(saveButton).toBeInTheDocument();
+
+    // Click the save button
+    fireEvent.click(saveButton);
+
+    // wait for popup to appear
+    const modal = await screen.findByTestId('save-report-modal');
+    expect(modal).toBeInTheDocument();
+
+    // Enter a report name
+    const reportNameInput = screen.getByLabelText(/Report Name/i);
+    expect(reportNameInput).toBeInTheDocument();
+    fireEvent.change(reportNameInput, { target: { value: 'Here :)' } });
+
+    fireEvent.click(screen.getByTestId('submit-report-name-summary'));
+
+    // Check if the input has entered an invalid state
+    expect(reportNameInput).toHaveAttribute('aria-invalid', 'true');
+
+    // Check if the correct error message is displayed
+    const errorMessage = screen.getByText('Report name is invalid. Only letters, numbers, !?& are allowed.');
+    expect(errorMessage).toBeInTheDocument();
+  });
+
   it('should call the saveReport function when the save button is clicked', async () => {
       render(<SummaryReport />);
     

--- a/wee/frontend/src/Utils/sanitizeInputText.ts
+++ b/wee/frontend/src/Utils/sanitizeInputText.ts
@@ -1,0 +1,12 @@
+export const sanitizeInputText = (text: string) => {
+    return text
+        .replace(/&/g, '&amp;')      // Escape &
+        .replace(/</g, '&lt;')       // Escape <
+        .replace(/>/g, '&gt;')       // Escape >
+        .replace(/"/g, '&quot;')     // Escape "
+        .replace(/'/g, '&#039;')     // Escape '
+        .replace(/`/g, '&#x60;')     // Escape `
+        .replace(/\(/g, '&#40;')     // Escape (
+        .replace(/\)/g, '&#41;')     // Escape )
+        .replace(/\//g, '&#x2F;');   // Escape /
+};

--- a/wee/frontend/src/app/(pages)/help/page.tsx
+++ b/wee/frontend/src/app/(pages)/help/page.tsx
@@ -8,6 +8,7 @@ import WEEInput from '../../components/Util/Input';
 import WEETextarea from '../../components/Util/Textarea';
 import useBeforeUnload from '../../hooks/useBeforeUnload';
 import { submitFeedback } from '../../services/feedback';
+import { sanitizeInputText } from '../../../Utils/sanitizeInputText';
 
 const faqs = [
   {
@@ -149,7 +150,7 @@ export default function Help() {
       return () => clearTimeout(timer);
     }
 
-    const { success, error: feedbackError } = await submitFeedback(email, name, message);
+    const { success, error: feedbackError } = await submitFeedback(email, sanitizeInputText(name), sanitizeInputText(message));
 
     if (success) {
       setSuccess('Feedback submitted successfully');

--- a/wee/frontend/src/app/(pages)/results/page.tsx
+++ b/wee/frontend/src/app/(pages)/results/page.tsx
@@ -277,6 +277,7 @@ function ResultsComponent() {
   const [reportName, setReportName] = useState('');
   const [isInvalid, setIsInvalid] = useState(false);
   const [isDisabled, setIsDisabled] = useState(true);
+  const [error, setError] = useState('');
   const { isOpen, onOpenChange } = useDisclosure();
   const { isOpen: isSuccessOpen, onOpenChange: onSuccessOpenChange } = useDisclosure();
 
@@ -293,12 +294,21 @@ function ResultsComponent() {
   };
 
   const handleSave = async (reportName: string) => {
+    const onlyLettersPattern = /^[A-Za-z0-9!?&\s]+$/; 
+
     reportName = reportName.trim();
     if (reportName.length === 0) {
       setIsInvalid(true);
       setIsDisabled(true);
       return;
     }
+    else if (!onlyLettersPattern.test(reportName)) {
+      setIsInvalid(true);
+      setIsDisabled(true);
+      setError("Report name is invalid. Only letters, numbers, !?& are allowed.");
+      return;
+    }
+
     const urlResults = results.filter((res) => res.url === url);
     if (urlResults && urlResults[0]) {
       try {
@@ -323,6 +333,7 @@ function ResultsComponent() {
       setReportName('');
       setIsInvalid(false);
       setIsDisabled(true);
+      setError('');
     }
   }, [isOpen]);
 
@@ -2216,7 +2227,13 @@ function ResultsComponent() {
                   variant="bordered"
                   isInvalid={isInvalid}
                   color={isInvalid ? "danger" : "default"}
-                  errorMessage="Please provide a name for the report"
+                  errorMessage={
+                    isInvalid
+                      ? error === ''
+                        ? 'A name must be provided for the report.'
+                        : error
+                      : undefined
+                  }
                   value={reportName}
                   onChange={handleInputChange}
                 />

--- a/wee/frontend/src/app/(pages)/scheduledscrape/page.tsx
+++ b/wee/frontend/src/app/(pages)/scheduledscrape/page.tsx
@@ -37,6 +37,10 @@ export default function ScheduledScrape() {
 
   useBeforeUnload();
 
+  const sanitizeKeyword = (_keyword: string) => {
+    return _keyword.replace(/[<>"'`;()]/g, '');
+  }
+
   // Add keyword to keyword list
    const handleAddKeyword = () => {
     // show error message if the keyword list exceeds a length of 3
@@ -57,6 +61,13 @@ export default function ScheduledScrape() {
     }
     else if (keywordList.length == 3 && keyword.trim() !== '') {
       setModalError("Max of 3 keywords can be tracked");
+      const timer = setTimeout(() => {
+        setModalError('');
+      }, 3000);
+      return () => clearTimeout(timer);
+    }
+    else if (keyword !== sanitizeKeyword(keyword)) {
+      setModalError('Keywords cannot contain special characters like <, >, ", \', `, ;, (, or )');
       const timer = setTimeout(() => {
         setModalError('');
       }, 3000);

--- a/wee/frontend/src/app/(pages)/summaryreport/page.tsx
+++ b/wee/frontend/src/app/(pages)/summaryreport/page.tsx
@@ -160,7 +160,7 @@ export default function SummaryReport() {
         onOpenChange();
         // report saved successfully popup
         onSuccessOpenChange();
-        
+
       } catch (error) {
         console.error("Error saving report:", error);
       }
@@ -775,6 +775,7 @@ export default function SummaryReport() {
                   className="text-md font-poppins-semibold bg-jungleGreen-700 text-dark-primaryTextColor dark:bg-jungleGreen-400 dark:text-primaryTextColor"
                   onPress={() => handleSave(reportName)}
                   disabled={isDisabled}
+                  data-testid="submit-report-name-summary"
                 >
                   Save
                 </Button>

--- a/wee/frontend/src/app/(pages)/summaryreport/page.tsx
+++ b/wee/frontend/src/app/(pages)/summaryreport/page.tsx
@@ -117,6 +117,7 @@ export default function SummaryReport() {
   const [reportName, setReportName] = useState('');
   const [isInvalid, setIsInvalid] = useState(false);
   const [isDisabled, setIsDisabled] = useState(true);
+  const [error, setError] = useState('');
   const { isOpen, onOpenChange } = useDisclosure();
   const { isOpen: isSuccessOpen, onOpenChange: onSuccessOpenChange } = useDisclosure();
 
@@ -133,6 +134,21 @@ export default function SummaryReport() {
   };
 
   const handleSave = async (reportName: string) => {
+    const onlyLettersPattern = /^[A-Za-z0-9!?&\s]+$/; 
+
+    reportName = reportName.trim();
+    if (reportName.length === 0) {
+      setIsInvalid(true);
+      setIsDisabled(true);
+      return;
+    }
+    else if (!onlyLettersPattern.test(reportName)) {
+      setIsInvalid(true);
+      setIsDisabled(true);
+      setError("Report name is invalid. Only letters, numbers, !?& are allowed.");
+      return;
+    }
+
     if (summaryReport) {
       try {
         await saveReport({
@@ -144,6 +160,7 @@ export default function SummaryReport() {
         onOpenChange();
         // report saved successfully popup
         onSuccessOpenChange();
+        
       } catch (error) {
         console.error("Error saving report:", error);
       }
@@ -156,6 +173,7 @@ export default function SummaryReport() {
       setReportName('');
       setIsInvalid(false);
       setIsDisabled(true);
+      setError('');
     }
   }, [isOpen]);
 
@@ -738,7 +756,13 @@ export default function SummaryReport() {
                   variant="bordered"
                   isInvalid={isInvalid}
                   color={isInvalid ? "danger" : "default"}
-                  errorMessage="Please provide a report name"
+                  errorMessage={
+                    isInvalid
+                      ? error === ''
+                        ? 'A name must be provided for the report.'
+                        : error
+                      : undefined
+                  }
                   value={reportName}
                   onChange={handleInputChange}
                 />


### PR DESCRIPTION
## Description
Security update

## Changes Made
Make sure that user can't enter funny characters into inputs
- help page: allow users to enter any characters but it gets replaced with HTML entities (maybe its a bit unnecessary especially since we never display this info on frontend again)
![image](https://github.com/user-attachments/assets/905dde5f-a997-4396-a5f3-eae79dd02e1e)
![image](https://github.com/user-attachments/assets/cd9e7054-2fb3-40d3-985a-b51c0a6d2db2)
![image](https://github.com/user-attachments/assets/bb437d75-a971-421f-ab94-c7e377716fec)

- report names for individual and summary page
![image](https://github.com/user-attachments/assets/f972bfc9-cdfa-4af7-a319-6e8a19afc7b8)

- sanitize keywords on scheduled scrape page
![image](https://github.com/user-attachments/assets/e8931d9f-68c3-44e3-93fe-0f34fc808536)

## Screenshots (if applicable)
See above

## Related Issues
#482 

## Checklist
- [ ] I have tested this code locally
- [ ] I have reviewed the code for readability and maintainability
- [ ] I have added appropriate documentation or updated existing documentation
- [ ] I have ensured that my changes follow the project's coding conventions
- [ ] I have performed additional steps, if required [e.g., database migrations, configuration changes, etc.]

## Additional Notes
[Include any additional notes or context relevant to the pull request]
