### PR TITLE
Hotfix/spelling cache styling rephrasing other

### DIFF
--- a/wee/api-service/src/scraper/scraper.module.ts
+++ b/wee/api-service/src/scraper/scraper.module.ts
@@ -21,7 +21,7 @@ import { PubSubModule } from '../pub-sub/pub_sub.module';
       imports: [ConfigModule],
       useFactory: async (config) => {
         const store = await redisStore({
-          ttl: 60 * 60 * 1000, // 60 minutes in cache
+          ttl: 24 * 60 * 60 * 1000, // 24 hours in cache
           socket: {
             host: config.get('redis.host'),
             port: config.get('redis.port')

--- a/wee/frontend/specs/unit/Dashboard.spec.tsx
+++ b/wee/frontend/specs/unit/Dashboard.spec.tsx
@@ -81,7 +81,7 @@ describe('Dashboard page - no data', () => {
 
         const dashboardLightHouse = screen.queryByTestId('dashboard-lighthouse-not-available');
         expect(dashboardLightHouse).toBeInTheDocument();
-        expect(dashboardLightHouse).toHaveTextContent('There are no Ligth House Technical SEO Analysis currently available');
+        expect(dashboardLightHouse).toHaveTextContent('There are no Light House Technical SEO Analysis currently available');
     });
 
     it('SEO Tech Analysis Site Speed section is not available', () => {

--- a/wee/frontend/specs/unit/Results.spec.tsx
+++ b/wee/frontend/specs/unit/Results.spec.tsx
@@ -88,7 +88,7 @@ describe('Results Component', () => {
                         "score": 15
                     }
                 ],
-                zeroShotMetaDataClassify: [                    
+                zeroShotMetaDataClassify: [
                     {
                         "label": "Tech",
                         "score": 69
@@ -100,7 +100,7 @@ describe('Results Component', () => {
                     {
                         "label": "Marine Resources",
                         "score": 18
-                    }                    
+                    }
                 ]
 
             },
@@ -117,20 +117,20 @@ describe('Results Component', () => {
             },
             sentiment: {
                 sentimentAnalysis: {
-                  positive: 0.94,
-                  negative: 0.001,
-                  neutral: 0.05,
+                    positive: 0.94,
+                    negative: 0.001,
+                    neutral: 0.05,
                 },
                 positiveWords: ['Flame', '100%', 'choice'],
                 negativeWords: ['Nothing', 'slaps'],
                 emotions: {
-                  neutral: 0.88,
-                  joy: 0.02,
-                  surprise: 0.1,
-                  anger: 0.01,
-                  disgust: 0.2,
-                  sadness: 0.003,
-                  fear: 0.002,
+                    neutral: 0.88,
+                    joy: 0.02,
+                    surprise: 0.1,
+                    anger: 0.01,
+                    disgust: 0.2,
+                    sadness: 0.003,
+                    fear: 0.002,
                 },
             },
             seoAnalysis: {
@@ -193,9 +193,10 @@ describe('Results Component', () => {
                     }
                 },
                 metaDescriptionAnalysis: {
-                    length: 80,
-                    recommendations: "Title tag length should be between 50 and 60 characters.",
-                    titleTag: "South African Online Computer Store",
+                    isUrlWordsInDescription: false,
+                    length: 88,
+                    metaDescription: "Buy computers, hardware, software, laptops & more from South Africa's best online store.",
+                    recommendations: 'Meta description length should be between 120 and 160 characters. Consider including words from the URL in the meta description: wootware.',
                 },
                 mobileFriendlinessAnalysis: {
                     isResponsive: true,
@@ -210,10 +211,9 @@ describe('Results Component', () => {
                     recommendations: "Your site currently lacks structured data, which can help search engines understand your content better. Consider implementing structured data using Schema.org to enhance visibility and improve your SEO.",
                 },
                 titleTagsAnalysis: {
-                    isUrlWordsInDescription: false,
-                    length: 88,
-                    metaDescription: "Buy computers, hardware, software, laptops & more from South Africa's best online store.",
-                    recommendations: 'Meta description length should be between 120 and 160 characters. Consider including words from the URL in the meta description: wootware.',
+                    length: 80,
+                    recommendations: "Title tag length should be between 50 and 60 characters.",
+                    titleTag: "South African Online Computer Store",
                 },
                 uniqueContentAnalysis: {
                     recommendations: '',
@@ -365,7 +365,7 @@ describe('Results Component', () => {
                                 "score": 0.1515
                             }
                         ],
-                        zeroShotMetaDataClassify: [                    
+                        zeroShotMetaDataClassify: [
                             {
                                 "label": "Tech",
                                 "score": 0.6969
@@ -377,9 +377,9 @@ describe('Results Component', () => {
                             {
                                 "label": "Marine Resources",
                                 "score": 0.1818
-                            }                    
+                            }
                         ]
-        
+
                     },
                 },
             ],
@@ -430,7 +430,7 @@ describe('Results Component', () => {
                                 "score": 0
                             }
                         ],
-                        zeroShotMetaDataClassify: [                    
+                        zeroShotMetaDataClassify: [
                             {
                                 "label": "Tech",
                                 "score": 0.6969
@@ -442,9 +442,9 @@ describe('Results Component', () => {
                             {
                                 "label": "Marine Resources",
                                 "score": 0.1818
-                            }                    
+                            }
                         ]
-        
+
                     },
                 },
             ],
@@ -490,7 +490,7 @@ describe('Results Component', () => {
                                 "score": 0.1515
                             }
                         ],
-                        zeroShotMetaDataClassify: [                    
+                        zeroShotMetaDataClassify: [
                             {
                                 "label": "Unknown",
                                 "score": 0
@@ -502,9 +502,9 @@ describe('Results Component', () => {
                             {
                                 "label": "Unknown",
                                 "score": 0
-                            }                
+                            }
                         ]
-        
+
                     },
                 },
             ],
@@ -847,7 +847,7 @@ describe('Results Component', () => {
         });
     });
 
-    it('Onpage SEO: Meta Description - display title tag, length and recommendation', async () => {
+    it('Onpage SEO: Meta Description - display metadescription, length and recommendation', async () => {
         await act(async () => {
             render(<Results />);
         });
@@ -856,14 +856,15 @@ describe('Results Component', () => {
         fireEvent.click(SEOTab);
 
         await waitFor(() => {
-            expect(screen.getByText(mockResults[0].seoAnalysis.metaDescriptionAnalysis.titleTag)).toBeDefined();
+            expect(screen.getByText(mockResults[0].seoAnalysis.metaDescriptionAnalysis.metaDescription)).toBeDefined();
             expect(screen.getByText(mockResults[0].seoAnalysis.metaDescriptionAnalysis.length)).toBeDefined();
+            expect(screen.getByText('No')).toBeDefined();
             expect(screen.queryByTestId('meta_recommendations')).toBeInTheDocument();
             expect(screen.getByText(mockResults[0].seoAnalysis.metaDescriptionAnalysis.recommendations)).toBeDefined();
         });
     });
 
-    it('Onpage SEO: Meta Description - display title tag, length and NO recommendation', async () => {
+    it('Onpage SEO: Meta Description - metadata description, length, is url in description and NO recommendation', async () => {
         (useScrapingContext as jest.Mock).mockReturnValueOnce({
             results: [
                 {
@@ -871,9 +872,10 @@ describe('Results Component', () => {
                     seoAnalysis: {
                         ...mockResults[0].seoAnalysis,
                         metaDescriptionAnalysis: {
-                            length: 55,
+                            isUrlWordsInDescription: true,
+                            length: 121,
+                            metaDescription: "Meta description for title tag analysis",
                             recommendations: '',
-                            titleTag: "South African Online Computer Store",
                         },
                     }
                 },
@@ -888,8 +890,9 @@ describe('Results Component', () => {
         fireEvent.click(SEOTab);
 
         await waitFor(() => {
-            expect(screen.getByText(mockResults[0].seoAnalysis.metaDescriptionAnalysis.titleTag)).toBeDefined();
-            expect(screen.getByText('55')).toBeDefined();
+            expect(screen.getByText("Meta description for title tag analysis")).toBeDefined();
+            expect(screen.getByText("121")).toBeDefined();
+            expect(screen.queryByTestId('isUrlWordsInDescription')?.textContent).toBe('Yes');
             expect(screen.queryByTestId('meta_recommendations')).not.toBeInTheDocument();
         });
     });
@@ -952,7 +955,7 @@ describe('Results Component', () => {
         });
     });
 
-    it('Onpage SEO: Title Tags - metadata description, length, is url in description and recommendation', async () => {
+    it('Onpage SEO: Title Tags - title tag, length and recommendation', async () => {
         await act(async () => {
             render(<Results />);
         });
@@ -961,15 +964,14 @@ describe('Results Component', () => {
         fireEvent.click(SEOTab);
 
         await waitFor(() => {
-            expect(screen.getByText(mockResults[0].seoAnalysis.titleTagsAnalysis.metaDescription)).toBeDefined();
+            expect(screen.getByText(mockResults[0].seoAnalysis.titleTagsAnalysis.titleTag)).toBeDefined();
             expect(screen.getByText(mockResults[0].seoAnalysis.titleTagsAnalysis.length)).toBeDefined();
-            expect(screen.getByText('No')).toBeDefined();
             expect(screen.queryByTestId('titleTag_recommendations')).toBeInTheDocument();
             expect(screen.getByText(mockResults[0].seoAnalysis.titleTagsAnalysis.recommendations)).toBeDefined();
         });
     });
 
-    it('Onpage SEO: Title Tags - metadata description, length, is url in description and NO recommendation', async () => {
+    it('Onpage SEO: Title Tags - title tag, length and NO recommendation', async () => {
         (useScrapingContext as jest.Mock).mockReturnValueOnce({
             results: [
                 {
@@ -977,10 +979,9 @@ describe('Results Component', () => {
                     seoAnalysis: {
                         ...mockResults[0].seoAnalysis,
                         titleTagsAnalysis: {
-                            isUrlWordsInDescription: true,
-                            length: 121,
-                            metaDescription: "Meta description for title tag analysis",
+                            length: 55,
                             recommendations: '',
+                            titleTag: "South African Online Computer Store",
                         },
                     }
                 },
@@ -995,9 +996,8 @@ describe('Results Component', () => {
         fireEvent.click(SEOTab);
 
         await waitFor(() => {
-            expect(screen.getByText("Meta description for title tag analysis")).toBeDefined();
-            expect(screen.getByText("121")).toBeDefined();
-            expect(screen.queryByTestId('titletagWordsInDesr')?.textContent).toBe('Yes');
+            expect(screen.getByText(mockResults[0].seoAnalysis.titleTagsAnalysis.titleTag)).toBeDefined();
+            expect(screen.getByText('55')).toBeDefined();
             expect(screen.queryByTestId('titleTag_recommendations')).not.toBeInTheDocument();
         });
     });
@@ -1173,7 +1173,7 @@ describe('Results Component', () => {
         });
     });
 
-    it('Technical SEO: Canonical Tags', async() => {
+    it('Technical SEO: Canonical Tags', async () => {
         await act(async () => {
             render(<Results />);
         });
@@ -1189,7 +1189,7 @@ describe('Results Component', () => {
         });
     })
 
-    it('Technical SEO: Canonical Tags, NO tag present', async() => {
+    it('Technical SEO: Canonical Tags, NO tag present', async () => {
         (useScrapingContext as jest.Mock).mockReturnValueOnce({
             results: [
                 {
@@ -1221,7 +1221,7 @@ describe('Results Component', () => {
         });
     })
 
-    it('Technical SEO: Site Speed', async() => {
+    it('Technical SEO: Site Speed', async () => {
         await act(async () => {
             render(<Results />);
         });
@@ -1236,7 +1236,7 @@ describe('Results Component', () => {
         });
     });
 
-    it('Technical SEO: Site Speed with zero loadtime', async() => {
+    it('Technical SEO: Site Speed with zero loadtime', async () => {
         (useScrapingContext as jest.Mock).mockReturnValueOnce({
             results: [
                 {
@@ -1488,7 +1488,7 @@ describe('Results Component', () => {
             expect(screen.getByText(mockResults[0].seoAnalysis.structuredDataAnalysis.recommendations)).toBeDefined();
         });
     });
-    
+
     it('Technical SEO: Lighthouse analysis', async () => {
         await act(async () => {
             render(<Results />);
@@ -1551,20 +1551,20 @@ describe('Results Component', () => {
                     ...mockResults[0],
                     sentiment: {
                         sentimentAnalysis: {
-                          positive: 0.90,
-                          negative: 0.02,
-                          neutral: 0.08,
+                            positive: 0.90,
+                            negative: 0.02,
+                            neutral: 0.08,
                         },
                         positiveWords: ['Flame', '100%', 'choice'],
                         negativeWords: ['Nothing', 'slaps'],
                         emotions: {
-                          neutral: 0.88,
-                          joy: 0.02,
-                          surprise: 0.1,
-                          anger: 0.01,
-                          disgust: 0.2,
-                          sadness: 0.003,
-                          fear: 0.002,
+                            neutral: 0.88,
+                            joy: 0.02,
+                            surprise: 0.1,
+                            anger: 0.01,
+                            disgust: 0.2,
+                            sadness: 0.003,
+                            fear: 0.002,
                         },
                     },
                 },
@@ -1578,7 +1578,7 @@ describe('Results Component', () => {
         const SentimentTab = screen.getByRole('tab', { name: /Sentiment Analysis/i });
         fireEvent.click(SentimentTab);
 
-        await waitFor(() => {            
+        await waitFor(() => {
             expect(screen.getByTestId('sentiment-donut-chart')).toBeInTheDocument();
 
             const sentimentMetaTitleDiv = screen.getByTestId('sentiment-meta-title');
@@ -1608,20 +1608,20 @@ describe('Results Component', () => {
                     ...mockResults[0],
                     sentiment: {
                         sentimentAnalysis: {
-                          positive: 0.90,
-                          negative: 0.02,
-                          neutral: 0.08,
+                            positive: 0.90,
+                            negative: 0.02,
+                            neutral: 0.08,
                         },
                         positiveWords: [],
                         negativeWords: [],
                         emotions: {
-                          neutral: 0.88,
-                          joy: 0.02,
-                          surprise: 0.1,
-                          anger: 0.01,
-                          disgust: 0.2,
-                          sadness: 0.003,
-                          fear: 0.002,
+                            neutral: 0.88,
+                            joy: 0.02,
+                            surprise: 0.1,
+                            anger: 0.01,
+                            disgust: 0.2,
+                            sadness: 0.003,
+                            fear: 0.002,
                         },
                     },
                 },
@@ -1635,7 +1635,7 @@ describe('Results Component', () => {
         const SentimentTab = screen.getByRole('tab', { name: /Sentiment Analysis/i });
         fireEvent.click(SentimentTab);
 
-        await waitFor(() => {            
+        await waitFor(() => {
             expect(screen.getByTestId('sentiment-donut-chart')).toBeInTheDocument();
 
             const sentimentMetaTitleDiv = screen.queryByTestId('sentiment-meta-title');
@@ -1660,9 +1660,9 @@ describe('Results Component', () => {
                     ...mockResults[0],
                     sentiment: {
                         sentimentAnalysis: {
-                          positive: 0.90,
-                          negative: 0.02,
-                          neutral: 0.08,
+                            positive: 0.90,
+                            negative: 0.02,
+                            neutral: 0.08,
                         },
                         positiveWords: ['Flame', '100%', 'choice'],
                         negativeWords: ['Nothing', 'slaps'],
@@ -1679,7 +1679,7 @@ describe('Results Component', () => {
         const SentimentTab = screen.getByRole('tab', { name: /Sentiment Analysis/i });
         fireEvent.click(SentimentTab);
 
-        await waitFor(() => {            
+        await waitFor(() => {
             expect(screen.getByTestId('sentiment-donut-chart')).toBeInTheDocument();
 
             const sentimentMetaTitleDiv = screen.getByTestId('sentiment-meta-title');
@@ -1710,20 +1710,20 @@ describe('Results Component', () => {
                     ...mockResults[0],
                     sentiment: {
                         sentimentAnalysis: {
-                          positive: 0,
-                          negative: 0,
-                          neutral: 0,
+                            positive: 0,
+                            negative: 0,
+                            neutral: 0,
                         },
                         positiveWords: ['Flame', '100%', 'choice'],
                         negativeWords: ['Nothing', 'slaps'],
                         emotions: {
-                          neutral: 0.88,
-                          joy: 0.02,
-                          surprise: 0.1,
-                          anger: 0.01,
-                          disgust: 0.2,
-                          sadness: 0.003,
-                          fear: 0.002,
+                            neutral: 0.88,
+                            joy: 0.02,
+                            surprise: 0.1,
+                            anger: 0.01,
+                            disgust: 0.2,
+                            sadness: 0.003,
+                            fear: 0.002,
                         },
                     },
                 },
@@ -1737,7 +1737,7 @@ describe('Results Component', () => {
         const SentimentTab = screen.getByRole('tab', { name: /Sentiment Analysis/i });
         fireEvent.click(SentimentTab);
 
-        await waitFor(() => {            
+        await waitFor(() => {
             expect(screen.queryByTestId('sentiment-donut-chart')).not.toBeInTheDocument();
             expect(screen.queryByText('No sentiment analysis data to display')).toBeInTheDocument();
 
@@ -2148,7 +2148,7 @@ describe('Results Component', () => {
 
         // Check if the input has entered an invalid state
         expect(reportNameInput).toHaveAttribute('aria-invalid', 'true');
-    
+
         // Check if the correct error message is displayed
         const errorMessage = screen.getByText('Report name is invalid. Only letters, numbers, !?& are allowed.');
         expect(errorMessage).toBeInTheDocument();

--- a/wee/frontend/src/app/(pages)/dashboard/page.tsx
+++ b/wee/frontend/src/app/(pages)/dashboard/page.tsx
@@ -313,7 +313,7 @@ function DashboardPage() {
 						) : (
 							<div data-testid="dashboard-lighthouse-not-available" className='bg-zinc-200 dark:bg-zinc-700 p-4 rounded-xl text-center'>
 								<p>
-									There are no Ligth House Technical SEO Analysis currently available
+									There are no Light House Technical SEO Analysis currently available
 								</p>
 							</div>
 						)}

--- a/wee/frontend/src/app/(pages)/results/page.tsx
+++ b/wee/frontend/src/app/(pages)/results/page.tsx
@@ -58,7 +58,7 @@ export default function Results() {
 }
 
 function isTitleTagAnalysis(data: TitleTagsAnalysis | SEOError): data is TitleTagsAnalysis {
-  return 'length' in data || 'metaDescription' in data || 'recommendations' in data || 'isUrlWordsInDescription' in data;
+  return 'length' in data || 'titleTag' in data || 'recommendations' in data;
 }
 
 function isHeadingAnalysis(data: HeadingAnalysis | SEOError): data is HeadingAnalysis {
@@ -74,7 +74,7 @@ function isInternalLinkAnalysis(data: InternalLinksAnalysis | SEOError): data is
 }
 
 function isMetaDescriptionAnalysis(data: MetaDescriptionAnalysis | SEOError): data is MetaDescriptionAnalysis {
-  return 'length' in data || 'recommendations' in data || 'titleTag' in data;
+  return 'length' in data || 'recommendations' in data || 'metaDescription' in data || 'isUrlWordsInDescription' in data;
 }
 
 function isUniqueContentAnalysis(data: UniqueContentAnalysis | SEOError): data is UniqueContentAnalysis {
@@ -1250,9 +1250,9 @@ function ResultsComponent() {
                         <div>
                           <div className='py-1'>
                             <h5 className='font-poppins-semibold text-jungleGreen-700 dark:text-jungleGreen-100'>
-                              Title Tag
+                              Metadata Description:
                             </h5>
-                            <p data-testid="p-metadescription-tag">{metaDescriptionAnalysis?.titleTag}</p>
+                            <p data-testid="p-metadescription-tag">{metaDescriptionAnalysis?.metaDescription}</p>
                           </div>
 
                           <div className='py-1'>
@@ -1260,6 +1260,13 @@ function ResultsComponent() {
                               Length
                             </h5>
                             <p data-testid="p-metadescription-length">{metaDescriptionAnalysis?.length}</p>
+                          </div>
+
+                          <div className='py-1'>
+                            <h5 className='font-poppins-semibold text-jungleGreen-700 dark:text-jungleGreen-100'>
+                              Is URL in description?
+                            </h5>
+                            <p data-testid="isUrlWordsInDescription">{metaDescriptionAnalysis?.isUrlWordsInDescription == true ? 'Yes' : 'No'}</p>
                           </div>
 
                           {
@@ -1305,9 +1312,9 @@ function ResultsComponent() {
                         <div>
                           <div className='py-1'>
                             <h5 className='font-poppins-semibold text-jungleGreen-700 dark:text-jungleGreen-100'>
-                              Metadata Description
+                              Title Tags:
                             </h5>
-                            <p data-testid="p-titletag-description">{titleTagsAnalysis?.metaDescription}</p>
+                            <p data-testid="p-titletag-description">{titleTagsAnalysis?.titleTag}</p>
                           </div>
 
                           <div className='py-1'>
@@ -1315,13 +1322,6 @@ function ResultsComponent() {
                               Length
                             </h5>
                             <p data-testid="p-titletag-length">{titleTagsAnalysis?.length}</p>
-                          </div>
-
-                          <div className='py-1'>
-                            <h5 className='font-poppins-semibold text-jungleGreen-700 dark:text-jungleGreen-100'>
-                              Is URL in description?
-                            </h5>
-                            <p data-testid="titletagWordsInDesr">{titleTagsAnalysis?.isUrlWordsInDescription == true ? 'Yes' : 'No'}</p>
                           </div>
 
                           {

--- a/wee/frontend/src/app/(pages)/results/page.tsx
+++ b/wee/frontend/src/app/(pages)/results/page.tsx
@@ -119,6 +119,9 @@ function ResultsComponent() {
   const searchParams = useSearchParams();
   const url = searchParams.get('url');
 
+  // businessName
+  const [businessName, setBusinessName] = useState('');
+
   const [keywordError, setKeywordError] = useState('');
   const [keyword, setKeyword] = useState('');
   const [isKeywordLoading, setKeywordLoading] = useState(false);
@@ -174,6 +177,21 @@ function ResultsComponent() {
 
       if (urlResults && urlResults[0]) {
         console.log(urlResults[0]);
+        
+        // set business name
+        const parsedUrl = new URL(url);
+        const domainParts = parsedUrl.hostname.split('.').filter(part => part !== 'www');
+        const commonDomains = ['com', 'org', 'net', 'co', 'gov', 'edu'];
+        let business = '';
+        if (domainParts.length > 2 && commonDomains.includes(domainParts[domainParts.length - 2])) {
+          business = domainParts[domainParts.length - 3];
+        } else {
+          // Otherwise, get the second last or last part of the domain
+          business = domainParts.length > 1 ? domainParts[domainParts.length - 2] : domainParts[0];
+        }
+        
+        setBusinessName(business || url);
+
         setWebsiteStatus(urlResults[0].domainStatus === 'live' ? 'Live' : 'Parked');
 
         if ('errorStatus' in urlResults[0].robots) {
@@ -2165,6 +2183,9 @@ function ResultsComponent() {
                             ]}
                             legendPosition='right'
                           />
+                        </div>
+                        <div className='py-2 bg-jungleGreen-200/60 dark:bg-jungleGreen-400/40 p-2 rounded-xl mt-2'>
+                          The results displayed are the closest match to the news articles related to the business name provided: {businessName}
                         </div>
                         <div className='gap-3 grid md:grid-cols-2 my-3'>
                           {scrapeNews.map((news, index) => (

--- a/wee/frontend/src/app/(pages)/results/page.tsx
+++ b/wee/frontend/src/app/(pages)/results/page.tsx
@@ -1936,8 +1936,8 @@ function ResultsComponent() {
                     <InfoPopOver
                       data-testid="popup-emotions"
                       heading="Emotions Confidence Score"
-                      content="By analyzing users&apos; domain-specific metadata, we can discern specific emotional cues. This capability empowers users to fine-tune 
-                        their metadata settings, thereby invoking the desired emotional responses.
+                      content="By analyzing users&apos; domain-specific metadata, we can discern specific emotional cues. This capability empowers users to fine-tune their metadata settings, thereby invoking the desired emotional responses. 
+                        Each score indicates the model's confidence in detecting a specific emotion based on the metadata
                         </br></br>Note: WEE cannot guarantee the accuracy of the analysis as it is based on machine learning models."
                       placement="right-end"
                     />

--- a/wee/frontend/src/app/(pages)/results/page.tsx
+++ b/wee/frontend/src/app/(pages)/results/page.tsx
@@ -1937,7 +1937,7 @@ function ResultsComponent() {
                       data-testid="popup-emotions"
                       heading="Emotions Confidence Score"
                       content="By analyzing users&apos; domain-specific metadata, we can discern specific emotional cues. This capability empowers users to fine-tune their metadata settings, thereby invoking the desired emotional responses. 
-                        Each score indicates the model's confidence in detecting a specific emotion based on the metadata
+                        </br></br>Each score indicates the model&apos;s confidence in detecting a specific emotion based on the metadata
                         </br></br>Note: WEE cannot guarantee the accuracy of the analysis as it is based on machine learning models."
                       placement="right-end"
                     />

--- a/wee/frontend/src/app/(pages)/savedresults/page.tsx
+++ b/wee/frontend/src/app/(pages)/savedresults/page.tsx
@@ -46,7 +46,7 @@ export default function Results() {
 }
 
 function isTitleTagAnalysis(data: TitleTagsAnalysis | SEOError): data is TitleTagsAnalysis {
-  return 'length' in data || 'metaDescription' in data || 'recommendations' in data || 'isUrlWordsInDescription' in data;
+  return 'length' in data || 'titleTag' in data || 'recommendations' in data;
 }
 
 function isHeadingAnalysis(data: HeadingAnalysis | SEOError): data is HeadingAnalysis {
@@ -62,7 +62,7 @@ function isInternalLinkAnalysis(data: InternalLinksAnalysis | SEOError): data is
 }
 
 function isMetaDescriptionAnalysis(data: MetaDescriptionAnalysis | SEOError): data is MetaDescriptionAnalysis {
-  return 'length' in data || 'recommendations' in data || 'titleTag' in data;
+  return 'length' in data || 'recommendations' in data || 'metaDescription' in data || 'isUrlWordsInDescription' in data;
 }
 
 function isUniqueContentAnalysis(data: UniqueContentAnalysis | SEOError): data is UniqueContentAnalysis {
@@ -962,9 +962,9 @@ function ResultsComponent() {
                         <div>
                           <div className='py-1'>
                             <h5 className='font-poppins-semibold text-jungleGreen-700 dark:text-jungleGreen-100'>
-                              Title Tag
+                              Meta Description:
                             </h5>
-                            <p data-testid="p-metadescription-tag">{metaDescriptionAnalysis?.titleTag}</p>
+                            <p data-testid="p-metadescription-tag">{metaDescriptionAnalysis?.metaDescription}</p>
                           </div>
 
                           <div className='py-1'>
@@ -972,6 +972,13 @@ function ResultsComponent() {
                               Length
                             </h5>
                             <p data-testid="p-metadescription-length">{metaDescriptionAnalysis?.length}</p>
+                          </div>
+
+                          <div className='py-1'>
+                            <h5 className='font-poppins-semibold text-jungleGreen-700 dark:text-jungleGreen-100'>
+                              Is URL in description?
+                            </h5>
+                            <p data-testid="isUrlWordsInDescription">{metaDescriptionAnalysis?.isUrlWordsInDescription == true ? 'Yes' : 'No'}</p>
                           </div>
 
                           {
@@ -1017,9 +1024,9 @@ function ResultsComponent() {
                         <div>
                           <div className='py-1'>
                             <h5 className='font-poppins-semibold text-jungleGreen-700 dark:text-jungleGreen-100'>
-                              Metadata Description
+                              Title Tags:
                             </h5>
-                            <p data-testid="p-titletag-description">{titleTagsAnalysis?.metaDescription}</p>
+                            <p data-testid="p-titletag-description">{titleTagsAnalysis?.titleTag}</p>
                           </div>
 
                           <div className='py-1'>
@@ -1027,13 +1034,6 @@ function ResultsComponent() {
                               Length
                             </h5>
                             <p data-testid="p-titletag-length">{titleTagsAnalysis?.length}</p>
-                          </div>
-
-                          <div className='py-1'>
-                            <h5 className='font-poppins-semibold text-jungleGreen-700 dark:text-jungleGreen-100'>
-                              Is URL in description?
-                            </h5>
-                            <p data-testid="titletagWordsInDesr">{titleTagsAnalysis?.isUrlWordsInDescription == true ? 'Yes' : 'No'}</p>
                           </div>
 
                           {

--- a/wee/frontend/src/app/(pages)/scheduledscrape/page.tsx
+++ b/wee/frontend/src/app/(pages)/scheduledscrape/page.tsx
@@ -371,7 +371,7 @@ export default function ScheduledScrape() {
                   label="Start scraping date and time"
                   id="datepickerscheduledscrape"
                   hideTimeZone
-                  showMonthAndYearPickers
+                  // showMonthAndYearPickers
                   defaultValue={now(getLocalTimeZone()).add({minutes: 5})}
                   onChange={(value: any) => {
                     console.log('Selected date value:', value);

--- a/wee/frontend/src/app/(pages)/scheduledscrape/page.tsx
+++ b/wee/frontend/src/app/(pages)/scheduledscrape/page.tsx
@@ -372,7 +372,7 @@ export default function ScheduledScrape() {
                   id="datepickerscheduledscrape"
                   hideTimeZone
                   showMonthAndYearPickers
-                  defaultValue={now(getLocalTimeZone())}
+                  defaultValue={now(getLocalTimeZone()).add({minutes: 5})}
                   onChange={(value: any) => {
                     console.log('Selected date value:', value);
                     

--- a/wee/frontend/src/app/models/ScraperModels.ts
+++ b/wee/frontend/src/app/models/ScraperModels.ts
@@ -225,7 +225,7 @@ export interface StructuredDataAnalysis {
 }
 
 export interface TitleTagsAnalysis {
-  titleTag: boolean;
+  titleTag: string;
   length: number;
   recommendations: string;
 }

--- a/wee/frontend/src/app/models/ScraperModels.ts
+++ b/wee/frontend/src/app/models/ScraperModels.ts
@@ -203,9 +203,10 @@ export interface LightHouseRecommendations {
 }
 
 export interface MetaDescriptionAnalysis {
+  metaDescription: string;
   length: number;
+  isUrlWordsInDescription: boolean;
   recommendations: string;
-  titleTag: string;
 }
 
 export interface MobileFriendlinessAnalysis {
@@ -224,9 +225,8 @@ export interface StructuredDataAnalysis {
 }
 
 export interface TitleTagsAnalysis {
-  isUrlWordsInDescription: boolean;
+  titleTag: boolean;
   length: number;
-  metaDescription: string;
   recommendations: string;
 }
 

--- a/wee/frontend/src/mocks/reportMocks.ts
+++ b/wee/frontend/src/mocks/reportMocks.ts
@@ -59,9 +59,10 @@ export const mockSeoAnalysis: SeoAnalysis = {
     },
   },
   metaDescriptionAnalysis: {
+    isUrlWordsInDescription: false,
     length: 155,
     recommendations: "Meta description is well-formed, no changes needed.",
-    titleTag: "Home - Example Website",
+    metaDescription: "Home - Example Website",
   },
   mobileFriendlinessAnalysis: {
     isResponsive: true,
@@ -76,9 +77,8 @@ export const mockSeoAnalysis: SeoAnalysis = {
     recommendations: "Structured data is valid and correctly implemented.",
   },
   titleTagsAnalysis: {
-    isUrlWordsInDescription: false,
     length: 60,
-    metaDescription: "The best example website for your needs.",
+    titleTag: "The best example website for your needs.",
     recommendations: "Title tag length is optimal.",
   },
   uniqueContentAnalysis: {

--- a/wee/webscraper/src/scraper.module.ts
+++ b/wee/webscraper/src/scraper.module.ts
@@ -38,7 +38,7 @@ import { ScrapeReviewsService } from './scrape-reviews/scrape-reviews.service';
       imports: [ConfigModule],
       useFactory: async (config) => {
         const store = await redisStore({
-          ttl: 60 * 60 * 1000, // 60 minutes in cache
+          ttl: 24 * 60 * 60 * 1000, // 24 hours in cache
           socket: {
             host: config.get('redis.host'),
             port: config.get('redis.port')


### PR DESCRIPTION
## Description
Frontend usability fixes

## Changes Made
- updated cache in webscraper and api-service to 24 hours
- fixed seo analysis mix up for title and metadescription (frontend, model, testing)
- fixed lighthouse spelling on scheduled scrape page
- added message to news article to say it is the closest match when the business name is searched
- add 5 minutes to the default time for scheduled scrape
- fixed calendar (Saturday was cut off)
- fixed confidence score - button upgrade

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/761580c4-7dba-4542-91fe-4f29839d4ec0)
![image](https://github.com/user-attachments/assets/970aab74-4d46-4f71-b0ac-b24aecedd746)
![image](https://github.com/user-attachments/assets/4002bc5e-c52b-4f9b-b5c4-29b85542dc13)
![image](https://github.com/user-attachments/assets/e0c5c7c6-415b-4621-a00c-0ea4b0f5fda7)
![image](https://github.com/user-attachments/assets/cbb53415-74bb-4386-952c-4496e03cb068)

## Related Issues
#493 #494 #500 #503 #509 #513

## Checklist
- [ ] I have tested this code locally
- [ ] I have reviewed the code for readability and maintainability
- [ ] I have added appropriate documentation or updated existing documentation
- [ ] I have ensured that my changes follow the project's coding conventions
- [ ] I have performed additional steps, if required [e.g., database migrations, configuration changes, etc.]

## Additional Notes
[Include any additional notes or context relevant to the pull request]
