### PR TITLE
Hotfix/navbar scrape results

### DIFF
--- a/wee/frontend/specs/component/NavBar.spec.tsx
+++ b/wee/frontend/specs/component/NavBar.spec.tsx
@@ -59,9 +59,9 @@ describe('NavBar Component', () => {
     expect(screen.getByTestId('navTitle')).toBeInTheDocument();
   });
 
-  it('should navigate to home when Home link is clicked', () => {
+  it('should navigate to home when Start Scraping link is clicked', () => {
     render(<NavBar />);
-    fireEvent.click(screen.getByText('Home'));
+    fireEvent.click(screen.getByText('Start Scraping'));
     expect(mockPush).toHaveBeenCalledWith('/');
   });
 

--- a/wee/frontend/specs/component/NavBar.spec.tsx
+++ b/wee/frontend/specs/component/NavBar.spec.tsx
@@ -65,6 +65,12 @@ describe('NavBar Component', () => {
     expect(mockPush).toHaveBeenCalledWith('/');
   });
 
+  it('should navigate to scraper result page when Results link is clicked', () => {
+    render(<NavBar />);
+    fireEvent.click(screen.getByText('Results'));
+    expect(mockPush).toHaveBeenCalledWith('/scraperesults');
+  });
+
   it('should navigate to help when Help link is clicked', () => {
     render(<NavBar />);
     fireEvent.click(screen.getByText('Help'));

--- a/wee/frontend/src/app/(pages)/scraperesults/page.tsx
+++ b/wee/frontend/src/app/(pages)/scraperesults/page.tsx
@@ -178,7 +178,7 @@ function ResultsComponent() {
   }, [page, filteredItems, resultsPerPage]);
 
   useEffect(() => {
-    console.log('urls length: ', urls.length);
+    console.log('urls length: ', urls.length, urls);
     if (urls && urls.length > 0 && urls.length !== (results.length + errorResults.length + undefinedResults.length)) {
       urls.forEach((url) => {
         if (!processedUrls.includes(url) && !processingUrls.includes(url)) {

--- a/wee/frontend/src/app/(pages)/scraperesults/page.tsx
+++ b/wee/frontend/src/app/(pages)/scraperesults/page.tsx
@@ -179,7 +179,7 @@ function ResultsComponent() {
 
   useEffect(() => {
     console.log('urls length: ', urls.length, urls);
-    if (urls && urls.length > 0 && urls.length !== (results.length + errorResults.length + undefinedResults.length)) {
+    if (urls && urls.length > 0 && urls[0] !== '' && urls.length !== (results.length + errorResults.length + undefinedResults.length)) {
       urls.forEach((url) => {
         if (!processedUrls.includes(url) && !processingUrls.includes(url)) {
           // add to array of urls still being processed

--- a/wee/frontend/src/app/(pages)/scraperesults/page.tsx
+++ b/wee/frontend/src/app/(pages)/scraperesults/page.tsx
@@ -438,7 +438,7 @@ function ResultsComponent() {
           </TableColumn>
         </TableHeader>
 
-        <TableBody emptyContent={isLoading ? "" : "No results to display"}>
+        <TableBody emptyContent={isLoading ? "" : "No results to display. Begin scraping by going to the 'Start Scraping' page."}>
           {items.map((item, index) => (
             <TableRow key={index} data-testid="table-row">
               <TableCell >

--- a/wee/frontend/src/app/components/NavBar.tsx
+++ b/wee/frontend/src/app/components/NavBar.tsx
@@ -48,6 +48,10 @@ export default function NavBar() {
     router.push('/help');
   }
 
+  const handleScrapeResults = () => {
+    router.push('/scraperesults');
+  }
+
   const handleHome = () => {
     router.push('/');
   }
@@ -76,28 +80,28 @@ export default function NavBar() {
         onMenuOpenChange={setIsMenuOpen}
         className="bg-jungleGreen-700 text-dark-primaryTextColor dark:bg-jungleGreen-400 dark:text-primaryTextColor"
       >
-      <NavbarContent className="sm:hidden" justify="start">
+      <NavbarContent className="md:hidden" justify="start">
         <NavbarMenuToggle aria-label={isMenuOpen ? "Close menu" : "Open menu"} />
       </NavbarContent>
 
-      <NavbarContent className="sm:hidden pr-3" justify="center">
+      <NavbarContent className="md:hidden pr-3" justify="center">
         <NavbarBrand>            
           <p className="font-bold text-inherit" data-testid='navTitle'>WEE</p>
         </NavbarBrand>
       </NavbarContent>
 
-      <NavbarContent className="hidden sm:flex gap-4" justify="center">
+      <NavbarContent className="hidden md:flex gap-4" justify="center">
         <NavbarBrand>
           <p className="font-bold text-inherit">WEE</p>
         </NavbarBrand>
         <NavbarItem>
           <Link onClick={handleHome} className="text-dark-primaryTextColor dark:text-primaryTextColor cursor-pointer" >
-            Home
+            Start Scraping
           </Link>
         </NavbarItem>
-        <NavbarItem >            
-          <Link onClick={handleHelp} className="text-dark-primaryTextColor dark:text-primaryTextColor cursor-pointer">
-            Help
+        <NavbarItem>
+          <Link onClick={handleScrapeResults} className="text-dark-primaryTextColor dark:text-primaryTextColor cursor-pointer" >
+            Results
           </Link>
         </NavbarItem>
         <NavbarItem>
@@ -127,6 +131,11 @@ export default function NavBar() {
                   </Link>
                   
               )}
+        </NavbarItem>
+        <NavbarItem >            
+          <Link onClick={handleHelp} className="text-dark-primaryTextColor dark:text-primaryTextColor cursor-pointer">
+            Help
+          </Link>
         </NavbarItem>
       </NavbarContent>
 
@@ -177,16 +186,17 @@ export default function NavBar() {
             color="foreground"                
             size="lg"
           >
-            Home
+            Start Scraping
           </Link>
           <Link 
-            onClick={() => {handleHelp(); setIsMenuOpen(false)}} 
+            onClick={() => {handleScrapeResults(); setIsMenuOpen(false)}} 
             className="w-full"
             color="foreground"                
             size="lg"
           >
-            Help
+            Results
           </Link>
+
           {user &&           
             <Link 
               onClick={() => {handleSavedReports(); setIsMenuOpen(false)}} 
@@ -207,6 +217,14 @@ export default function NavBar() {
               Scheduled Tasks
             </Link>
           }
+          <Link 
+            onClick={() => {handleHelp(); setIsMenuOpen(false)}} 
+            className="w-full"
+            color="foreground"                
+            size="lg"
+          >
+            Help
+          </Link>
         </NavbarMenuItem>
       </NavbarMenu>
     </Navbar>


### PR DESCRIPTION
## Description
Made the navbar more user friendly

## Changes Made
- added a item to the navbar for the scrape result page
- there is no loader visible if the user navigated from the homepage to the scrape result page without starting a scraping task

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/f24ef788-7eed-4899-a48c-ecfb148efeb4)
![image](https://github.com/user-attachments/assets/d210a2b6-35d4-4eff-b0de-bd0793a11862)
![image](https://github.com/user-attachments/assets/b9c6c006-9d90-434c-a2e2-7c964df1c67b)

## Related Issues
#510

## Checklist
- [ ] I have tested this code locally
- [ ] I have reviewed the code for readability and maintainability
- [ ] I have added appropriate documentation or updated existing documentation
- [ ] I have ensured that my changes follow the project's coding conventions
- [ ] I have performed additional steps, if required [e.g., database migrations, configuration changes, etc.]

## Additional Notes
[Include any additional notes or context relevant to the pull request]
