### PR TITLE
added tooltip to the summary report button

### DIFF
--- a/wee/frontend/src/app/(pages)/scraperesults/page.tsx
+++ b/wee/frontend/src/app/(pages)/scraperesults/page.tsx
@@ -494,7 +494,19 @@ function ResultsComponent() {
           <h1 className="my-4 mt-6 font-poppins-bold text-2xl text-jungleGreen-800 dark:text-dark-primaryTextColor">
             Summary
           </h1>
-          <Button
+          {isLoading ||  results.length <= 1 ?
+            <Tooltip content="Only available if there are more than one result and all URLs have successfully loaded">
+              <Button
+                data-testid="btn-report-summary"
+                className="text-md font-poppins-semibold bg-jungleGreen-700 text-dark-primaryTextColor dark:bg-jungleGreen-400 dark:text-primaryTextColor disabled:bg-jungleGreen-600 disabled:dark:bg-jungleGreen-300 disabled:cursor-not-allowed"
+                onClick={handleSummaryPage}
+                disabled={isLoading || results.length <= 1}
+              >
+                View overall summary report
+              </Button>
+            </Tooltip>
+          :
+            <Button
             data-testid="btn-report-summary"
             className="text-md font-poppins-semibold bg-jungleGreen-700 text-dark-primaryTextColor dark:bg-jungleGreen-400 dark:text-primaryTextColor disabled:bg-jungleGreen-600 disabled:dark:bg-jungleGreen-300 disabled:cursor-not-allowed"
             onClick={handleSummaryPage}
@@ -502,6 +514,7 @@ function ResultsComponent() {
           >
             View overall summary report
           </Button>
+          }
         </div>
 
         <div>


### PR DESCRIPTION
## Description
Tooltip to explain to users why the summary button is disabled

## Changes Made
[List the specific changes made in this pull request]

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/d434d001-8aab-42a8-923e-567e3bddab45)
no tooltip if everything is loaded in
![image](https://github.com/user-attachments/assets/769f6253-2080-4f2b-99c9-040f951a4bf3)

## Related Issues
[Cite any related issues or feature requests]

## Checklist
- [ ] I have tested this code locally
- [ ] I have reviewed the code for readability and maintainability
- [ ] I have added appropriate documentation or updated existing documentation
- [ ] I have ensured that my changes follow the project's coding conventions
- [ ] I have performed additional steps, if required [e.g., database migrations, configuration changes, etc.]

## Additional Notes
[Include any additional notes or context relevant to the pull request]
